### PR TITLE
fix: 出码模版 npm 源

### DIFF
--- a/modules/code-generator/src/cli/run.ts
+++ b/modules/code-generator/src/cli/run.ts
@@ -89,7 +89,7 @@ async function getProjectBuilderFactory(
       console.log(`"${solution}" is not internal, installing it as ${solutionPackageName}...`);
     }
 
-    spawnSync('tnpm', ['i', solutionPackageName], {
+    spawnSync('npm', ['i', solutionPackageName], {
       stdio: quiet ? 'ignore' : 'inherit',
     });
   }


### PR DESCRIPTION
出码的模版 npm 源应该忘记替换了吧～ 外部只能使用内置 icejs 和 rax 模版了。另外这里扩展模版是不是应该不局限使用 @alilc/ 的 namespace？