### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/designer/src/designer/drag-ghost/index.tsx
+++ b/packages/designer/src/designer/drag-ghost/index.tsx
@@ -26,7 +26,7 @@ export default class DragGhost extends Component<{ designer: Designer }> {
     makeObservable(this);
     this.dispose = [
       this.dragon.onDragstart(e => {
-        if (e.originalEvent.type.substr(0, 4) === 'drag') {
+        if (e.originalEvent.type.slice(0, 4) === 'drag') {
           return;
         }
         this.dragObject = e.dragObject;

--- a/packages/designer/src/designer/setting/setting-prop-entry.ts
+++ b/packages/designer/src/designer/setting/setting-prop-entry.ts
@@ -56,7 +56,7 @@ export class SettingPropEntry implements SettingEntry {
   constructor(readonly parent: SettingEntry, name: string | number, type?: 'field' | 'group') {
     makeObservable(this);
     if (type == null) {
-      const c = typeof name === 'string' ? name.substr(0, 1) : '';
+      const c = typeof name === 'string' ? name.slice(0, 1) : '';
       if (c === '#') {
         this.type = 'group';
       } else {

--- a/packages/designer/src/document/node/props/props.ts
+++ b/packages/designer/src/document/node/props/props.ts
@@ -14,7 +14,7 @@ export function getConvertedExtraKey(key: string): string {
   if (key.indexOf('.') > 0) {
     _key = key.split('.')[0];
   }
-  return EXTRA_KEY_PREFIX + _key + EXTRA_KEY_PREFIX + key.substr(_key.length);
+  return EXTRA_KEY_PREFIX + _key + EXTRA_KEY_PREFIX + key.slice(_key.length);
 }
 export function getOriginalExtraKey(key: string): string {
   return key.replace(new RegExp(`${EXTRA_KEY_PREFIX}`, 'g'), '');

--- a/packages/designer/src/document/node/props/value-to-source.ts
+++ b/packages/designer/src/document/node/props/value-to-source.ts
@@ -66,7 +66,7 @@ export function valueToSource(
             indentString,
             lineEnding,
             visitedObjects: new Set([value, ...visitedObjects]),
-          }).substr(indentLevel * indentString.length)})`
+          }).slice(indentLevel * indentString.length)})`
           : `${indentString.repeat(indentLevel)}new Map()`;
       }
 
@@ -85,7 +85,7 @@ export function valueToSource(
             indentString,
             lineEnding,
             visitedObjects: new Set([value, ...visitedObjects]),
-          }).substr(indentLevel * indentString.length)})`
+          }).slice(indentLevel * indentString.length)})`
           : `${indentString.repeat(indentLevel)}new Set()`;
       }
 
@@ -129,7 +129,7 @@ export function valueToSource(
           if (item === null) {
             items.push(indentString.repeat(indentLevel + 1));
           } else if (itemsStayOnTheSameLine) {
-            items.push(item.substr(indentLevel * indentString.length));
+            items.push(item.slice(indentLevel * indentString.length));
           } else {
             items.push(item);
           }
@@ -166,11 +166,11 @@ export function valueToSource(
               doubleQuote,
             })
             : propertyName;
-          const trimmedPropertyValueString = propertyValueString.substr((indentLevel + 1) * indentString.length);
+          const trimmedPropertyValueString = propertyValueString.slice((indentLevel + 1) * indentString.length);
 
           if (typeof propertyValue === 'function' && trimmedPropertyValueString.startsWith(`${propertyName}()`)) {
             entries.push(
-              `${indentString.repeat(indentLevel + 1)}${quotedPropertyName} ${trimmedPropertyValueString.substr(
+              `${indentString.repeat(indentLevel + 1)}${quotedPropertyName} ${trimmedPropertyValueString.slice(
                 propertyName.length,
               )}`,
             );

--- a/packages/editor-core/src/widgets/tip/utils.ts
+++ b/packages/editor-core/src/widgets/tip/utils.ts
@@ -79,7 +79,7 @@ function resolvePrefer(prefer: any, targetRect: any, bounds: any) {
   }
   const force = prefer[0] === '!';
   if (force) {
-    prefer = prefer.substr(1);
+    prefer = prefer.slice(1);
   }
   let [dir, offset] = prefer.split(/\s+/);
   let forceDirection = false;

--- a/packages/rax-simulator-renderer/src/rax-use-router.js
+++ b/packages/rax-simulator-renderer/src/rax-use-router.js
@@ -59,7 +59,7 @@ function matchPath(route, pathname, parentParams) {
   }
 
   return {
-    path: !end && url.charAt(url.length - 1) === '/' ? url.substr(1) : url,
+    path: !end && url.charAt(url.length - 1) === '/' ? url.slice(1) : url,
     params,
   };
 }
@@ -96,7 +96,7 @@ function matchRoute(route, baseUrl, pathname, parentParams) {
             childMatches = matchRoute(
               childRoute,
               baseUrl + matched.path,
-              pathname.substr(matched.path.length),
+              pathname.slice(matched.path.length),
               matched.params,
             );
           }

--- a/packages/rax-simulator-renderer/src/renderer.ts
+++ b/packages/rax-simulator-renderer/src/renderer.ts
@@ -291,7 +291,7 @@ export class SimulatorRendererContainer implements BuiltinSimulatorRenderer {
     });
     this.history = history;
     history.listen(({ location }) => {
-      host.project.open(location.pathname.substr(1));
+      host.project.open(location.pathname.slice(1));
     });
     host.componentsConsumer.consume(async (componentsAsset) => {
       if (componentsAsset) {

--- a/packages/react-simulator-renderer/src/renderer.ts
+++ b/packages/react-simulator-renderer/src/renderer.ts
@@ -264,7 +264,7 @@ export class SimulatorRendererContainer implements BuiltinSimulatorRenderer {
     });
     this.history = history;
     history.listen((location, action) => {
-      const docId = location.pathname.substr(1);
+      const docId = location.pathname.slice(1);
       docId && host.project.open(docId);
     });
     host.componentsConsumer.consume(async (componentsAsset) => {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.