### PR TITLE
fix: compact devMode

### DIFF
--- a/packages/designer/src/designer/designer.ts
+++ b/packages/designer/src/designer/designer.ts
@@ -521,7 +521,7 @@ export class Designer {
     const designer = this;
     designer._componentMetasMap.forEach((config, key) => {
       const metaData = config.getMetadata();
-      if (metaData.devMode === 'lowcode') {
+      if (metaData.devMode && ['lowcode', 'lowCode'].includes(metaData.devMode)) {
         maps[key] = metaData.schema;
       } else {
         const view = metaData.configure.advanced?.view;

--- a/packages/designer/src/document/document-model.ts
+++ b/packages/designer/src/document/document-model.ts
@@ -26,7 +26,7 @@ export interface ComponentMap {
   destructuring?: boolean;
   exportName?: string;
   subName?: string;
-  devMode?: 'lowcode' | 'procode';
+  devMode?: 'lowcode' | 'procode' | 'proCode' | 'lowCode';
 }
 
 export class DocumentModel {

--- a/packages/designer/src/document/node/node.ts
+++ b/packages/designer/src/document/node/node.ts
@@ -1189,7 +1189,9 @@ export function isRootNode(node: Node): node is RootNode {
 }
 
 export function isLowCodeComponent(node: Node): boolean {
-  return node.componentMeta?.getMetadata().devMode === 'lowcode';
+  const devMode = node.componentMeta?.getMetadata?.()?.devMode;
+  if (!devMode) { return false; }
+  return ['lowcode', 'lowCode'].includes(devMode);
 }
 
 export function getZLevelTop(child: Node, zLevel: number): Node | null {

--- a/packages/types/src/metadata.ts
+++ b/packages/types/src/metadata.ts
@@ -379,7 +379,7 @@ export interface ComponentMetadata {
   /**
    * 组件研发模式
    */
-  devMode?: 'procode' | 'lowcode';
+  devMode?: 'procode' | 'lowcode' | 'proCode' | 'lowCode';
   /**
    * npm 源引入完整描述对象
    */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44559440/160810309-85b43418-61cb-47c4-9e8d-bad00a249dea.png)
![image](https://user-images.githubusercontent.com/44559440/160810724-2e673915-020c-44ef-a7bd-aa04964d66c1.png)

物料规范 和 入料模块 中 devMode 的定义都是 `proCode | lowCode`，但是引擎实现中是 `procode | lowcode`，建议引擎代码兼容下这两部分内容；