### PR TITLE
fix: add  @alilc/lowcode-designer in  dependencies

### DIFF
--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -18,6 +18,7 @@
   ],
   "author": "xiayang.xy",
   "dependencies": {
+    "@alilc/lowcode-designer": "1.0.3",
     "@alilc/lowcode-editor-core": "1.0.3",
     "react": "^16.8.1",
     "react-dom": "^16.8.1"

--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@alilc/lowcode-designer": "1.0.3",
     "@alilc/lowcode-editor-core": "1.0.3",
+    "@alilc/lowcode-utils": "1.0.3",
     "react": "^16.8.1",
     "react-dom": "^16.8.1"
   },


### PR DESCRIPTION
When I sorted out the dependencies by " package.json  dependencies  node " , I found the following error：
![image](https://user-images.githubusercontent.com/11750878/161930422-82f481eb-88d7-48a9-9692-294bae33b638.png)

