### PR TITLE
feat: add some features

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -1098,7 +1098,9 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
 
     // fix target : 浏览器事件响应目标
     if (!e.target || notMyEvent) {
-      e.target = this.contentDocument?.elementFromPoint(e.canvasX!, e.canvasY!);
+      if (!isNaN(e.canvasX!) && !isNaN(e.canvasY!)) {
+        e.target = this.contentDocument?.elementFromPoint(e.canvasX!, e.canvasY!);
+      }
     }
 
     // 事件已订正
@@ -1156,14 +1158,12 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
       return null;
     }
     const dropContainer = this.getDropContainer(e);
-    const canDropIn = dropContainer?.container?.componentMeta?.prototype?.options?.canDropIn;
+    const childWhitelist = dropContainer?.container?.componentMeta?.childWhitelist;
     const lockedNode = getClosestNode(dropContainer?.container as Node, (node) => node.isLocked);
     if (lockedNode) return null;
     if (
       !dropContainer ||
-      canDropIn === false ||
-      // too dirty
-      (nodes && typeof canDropIn === 'function' && !canDropIn(operationalNodes[0]))
+      (nodes && typeof childWhitelist === 'function' && !childWhitelist(operationalNodes[0]))
     ) {
       return null;
     }

--- a/packages/designer/src/designer/setting/setting-top-entry.ts
+++ b/packages/designer/src/designer/setting/setting-top-entry.ts
@@ -226,13 +226,11 @@ export class SettingTopEntry implements SettingEntry {
   }
 
 
-  // ==== compatibles for vision =====
   getProp(propName: string | number) {
     return this.get(propName);
   }
 
   // ==== copy some Node api =====
-  // `VE.Node.getProps`
   getStatus() {
 
   }

--- a/packages/designer/src/document/document-model.ts
+++ b/packages/designer/src/document/document-model.ts
@@ -642,6 +642,7 @@ export class DocumentModel {
       this.rootNodeVisitorMap[visitorName] = visitorResult;
     } catch (e) {
       console.error('RootNodeVisitor is not valid.');
+      console.error(e);
     }
     return visitorResult;
   }

--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -316,6 +316,7 @@ export class Prop implements IPropParent {
     const slotSchema: SlotSchema = {
       componentName: 'Slot',
       title: data.title,
+      id: data.id,
       name: data.name,
       params: data.params,
       children: data.value,

--- a/packages/designer/src/plugin/plugin-types.ts
+++ b/packages/designer/src/plugin/plugin-types.ts
@@ -48,6 +48,7 @@ export interface ILowCodePluginPreferenceDeclaration {
 export type PluginPreference = Map<string, Record<string, PreferenceValueType>>;
 
 export interface ILowCodePluginConfig {
+  dep?: string | string[];
   init?(): void;
   destroy?(): void;
   exports?(): any;
@@ -129,6 +130,10 @@ export interface ILowCodePluginManagerCore {
 }
 
 export type ILowCodePluginManager = ILowCodePluginManagerCore & ILowCodePluginManagerPluginAccessor;
+
+export function isLowCodeRegisterOptions(opts: any): opts is ILowCodeRegisterOptions {
+  return opts && ('autoInit' in opts || 'override' in opts);
+}
 
 export interface ILowCodeRegisterOptions {
   autoInit?: boolean;

--- a/packages/designer/src/plugin/plugin-utils.ts
+++ b/packages/designer/src/plugin/plugin-utils.ts
@@ -1,0 +1,28 @@
+import type { ILowCodePluginPreferenceDeclaration } from './plugin-types';
+import { isPlainObject } from 'lodash';
+
+export function isValidPreferenceKey(
+  key: string,
+  preferenceDeclaration: ILowCodePluginPreferenceDeclaration,
+): boolean {
+  if (!preferenceDeclaration || !Array.isArray(preferenceDeclaration.properties)) {
+    return false;
+  }
+  return preferenceDeclaration.properties.some((prop) => {
+    return prop.key === key;
+  });
+}
+
+export function filterValidOptions(opts: any, preferenceDeclaration: ILowCodePluginPreferenceDeclaration) {
+  if (!opts || !isPlainObject(opts)) return opts;
+  const filteredOpts = {} as any;
+  Object.keys(opts).forEach(key => {
+    if (isValidPreferenceKey(key, preferenceDeclaration)) {
+      const v = opts[key];
+      if (v !== undefined && v !== null) {
+        filteredOpts[key] = v;
+      }
+    }
+  });
+  return filteredOpts;
+}

--- a/packages/designer/src/plugin/plugin.ts
+++ b/packages/designer/src/plugin/plugin.ts
@@ -50,7 +50,11 @@ export class LowCodePlugin implements ILowCodePlugin {
     if (typeof this.meta.dependencies === 'string') {
       return [this.meta.dependencies];
     }
-    return this.meta.dependencies || [];
+    // compat legacy way to declare dependencies
+    if (typeof this.config.dep === 'string') {
+      return [this.config.dep];
+    }
+    return this.meta.dependencies || this.config.dep || [];
   }
 
   get disabled() {

--- a/packages/editor-core/src/editor.ts
+++ b/packages/editor-core/src/editor.ts
@@ -11,6 +11,7 @@ import {
   RemoteComponentDescription,
   GlobalEvent,
 } from '@alilc/lowcode-types';
+import { engineConfig } from './config';
 import { globalLocale } from './intl';
 import * as utils from './utils';
 import Preference from './utils/preference';
@@ -71,6 +72,8 @@ export class Editor extends (EventEmitter as any) implements IEditor {
       this.setAssets(data);
       return;
     }
+    // store the data to engineConfig while invoking editor.set()
+    engineConfig.set(key as any, data);
     this.context.set(key, data);
     this.notifyGot(key);
   }

--- a/packages/editor-skeleton/src/layouts/workbench.less
+++ b/packages/editor-skeleton/src/layouts/workbench.less
@@ -314,6 +314,7 @@ body {
       display: none;
       flex-shrink: 0;
       position: relative;
+      z-index: 820;
       &.lc-area-visible {
         display: block;
       }

--- a/packages/engine/src/engine-core.ts
+++ b/packages/engine/src/engine-core.ts
@@ -6,6 +6,7 @@ import {
   LowCodePluginManager,
   ILowCodePluginContext,
   PluginPreference,
+  TransformStage,
 } from '@alilc/lowcode-designer';
 import {
   Skeleton as InnerSkeleton,
@@ -22,7 +23,8 @@ import utils from './modules/utils';
 import * as editorCabin from './modules/editor-cabin';
 import getSkeletonCabin from './modules/skeleton-cabin';
 import getDesignerCabin from './modules/designer-cabin';
-
+import classes from './modules/classes';
+import symbols from './modules/symbols';
 export * from './modules/editor-types';
 export * from './modules/skeleton-types';
 export * from './modules/designer-types';
@@ -60,8 +62,12 @@ const config = engineConfig;
 const event = new Event(editor, { prefix: 'common' });
 const logger = getLogger({ level: 'warn', bizName: 'common' });
 const designerCabin = getDesignerCabin(editor);
+const objects = {
+  TransformStage,
+};
 const common = {
   utils,
+  objects,
   editorCabin,
   designerCabin,
   skeletonCabin,
@@ -80,6 +86,12 @@ export {
   common,
   // 兼容原 editor 的事件功能
   event as editor,
+};
+// declare this is open-source version
+export const isOpenSource = true;
+export const __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+  symbols,
+  classes,
 };
 
 // 注册一批内置插件

--- a/packages/engine/src/modules/classes.ts
+++ b/packages/engine/src/modules/classes.ts
@@ -1,0 +1,25 @@
+import {
+  Project,
+  Skeleton,
+  DocumentModel,
+  Node,
+  NodeChildren,
+  History,
+  SettingPropEntry,
+  SettingTopEntry,
+  Selection,
+} from '@alilc/lowcode-shell';
+import { Node as InnerNode } from '@alilc/lowcode-designer';
+
+export default {
+  Project,
+  Skeleton,
+  DocumentModel,
+  Node,
+  NodeChildren,
+  History,
+  SettingPropEntry,
+  SettingTopEntry,
+  InnerNode,
+  Selection,
+};

--- a/packages/engine/src/modules/designer-cabin.ts
+++ b/packages/engine/src/modules/designer-cabin.ts
@@ -3,6 +3,10 @@ import {
   isSettingField,
   Designer,
   TransformStage,
+  LiveEditing,
+  isDragNodeDataObject,
+  DragObjectType,
+  isNode,
 } from '@alilc/lowcode-designer';
 import { Editor } from '@alilc/lowcode-editor-core';
 import { Dragon } from '@alilc/lowcode-shell';
@@ -15,5 +19,9 @@ export default function getDesignerCabin(editor: Editor) {
     isSettingField,
     dragon: Dragon.create(designer.dragon),
     TransformStage,
+    LiveEditing,
+    DragObjectType,
+    isDragNodeDataObject,
+    isNode,
   };
 }

--- a/packages/engine/src/modules/designer-types.ts
+++ b/packages/engine/src/modules/designer-types.ts
@@ -13,3 +13,6 @@ export type ILowCodePluginConfig = designerCabin.ILowCodePluginConfig;
 export type ILowCodePluginManager = designerCabin.ILowCodePluginManager;
 export type ILowCodePluginContext = designerCabin.ILowCodePluginContext;
 export type PluginPreference = designerCabin.PluginPreference;
+export type PropsReducerContext = designerCabin.PropsReducerContext;
+export type DragObjectType = designerCabin.DragObjectType;
+export type DragNodeDataObject = designerCabin.DragNodeDataObject;

--- a/packages/engine/src/modules/editor-cabin.ts
+++ b/packages/engine/src/modules/editor-cabin.ts
@@ -3,12 +3,11 @@ export {
   Tip,
   shallowIntl,
   createIntl,
+  intl,
   createSetterContent,
-  // TODO: To be deleted
   obx,
+  untracked,
   computed,
   observer,
-  getSetter,
-  getSettersMap,
   globalLocale,
 } from '@alilc/lowcode-editor-core';

--- a/packages/engine/src/modules/symbols.ts
+++ b/packages/engine/src/modules/symbols.ts
@@ -1,0 +1,21 @@
+import {
+  projectSymbol,
+  documentSymbol,
+  nodeSymbol,
+  designerSymbol,
+  skeletonSymbol,
+  editorSymbol,
+  settingPropEntrySymbol,
+  settingTopEntrySymbol,
+} from '@alilc/lowcode-shell';
+
+export default {
+  projectSymbol,
+  documentSymbol,
+  nodeSymbol,
+  skeletonSymbol,
+  editorSymbol,
+  designerSymbol,
+  settingPropEntrySymbol,
+  settingTopEntrySymbol,
+};

--- a/packages/plugin-outline-pane/src/views/tree-title.tsx
+++ b/packages/plugin-outline-pane/src/views/tree-title.tsx
@@ -106,7 +106,11 @@ export default class TreeTitle extends Component<{
         data-id={treeNode.id}
         onClick={() => {
           if (isModal) {
-            node.document.modalNodesManager.setVisible(node);
+            if (node.getVisible()) {
+              node.document.modalNodesManager.setInvisible(node);
+            } else {
+              node.document.modalNodesManager.setVisible(node);
+            }
             return;
           }
           if (node.conditionGroup) {

--- a/packages/renderer-core/src/hoc/leaf.tsx
+++ b/packages/renderer-core/src/hoc/leaf.tsx
@@ -260,6 +260,10 @@ export function leafWrapper(Comp: types.IBaseRenderComponent, {
       this.initOnVisibleChangeEvent(_leaf);
       this.curEventLeaf = _leaf;
 
+      cache.ref.set(props.componentId, {
+        makeUnitRender: this.makeUnitRender,
+      });
+
       let cacheState = cache.state.get(props.componentId);
       if (!cacheState || cacheState.__tag !== props.__tag) {
         cacheState = this.defaultState;
@@ -557,7 +561,6 @@ export function leafWrapper(Comp: types.IBaseRenderComponent, {
     <LeafHoc
       {...props}
       forwardedRef={ref}
-      ref={(_ref: any) => cache.ref.set(props.componentId, _ref)}
     />
   ));
 

--- a/packages/shell/src/component-meta.ts
+++ b/packages/shell/src/component-meta.ts
@@ -1,8 +1,10 @@
 import {
   ComponentMeta as InnerComponentMeta,
+  ParentalNode,
 } from '@alilc/lowcode-designer';
-import { componentMetaSymbol } from './symbols';
-
+import Node from './node';
+import { NodeData, NodeSchema } from '@alilc/lowcode-types';
+import { componentMetaSymbol, nodeSymbol } from './symbols';
 
 export default class ComponentMeta {
   private readonly [componentMetaSymbol]: InnerComponentMeta;
@@ -76,6 +78,13 @@ export default class ComponentMeta {
   }
 
   /**
+   * @deprecated
+   */
+  get prototype() {
+    return this[componentMetaSymbol].prototype;
+  }
+
+  /**
    * 设置 npm 信息
    * @param npm
    */
@@ -89,5 +98,27 @@ export default class ComponentMeta {
    */
   getMetadata() {
     return this[componentMetaSymbol].getMetadata();
+  }
+
+  /**
+   * check if the current node could be placed in parent node
+   * @param my
+   * @param parent
+   * @returns
+   */
+  checkNestingUp(my: Node | NodeData, parent: ParentalNode<NodeSchema>) {
+    const curNode = my.isNode ? my[nodeSymbol] : my;
+    return this[componentMetaSymbol].checkNestingUp(curNode as any, parent);
+  }
+
+  /**
+   * check if the target node(s) could be placed in current node
+   * @param my
+   * @param parent
+   * @returns
+   */
+   checkNestingDown(my: Node | NodeData, target: NodeSchema | Node | NodeSchema[]) {
+    const curNode = my.isNode ? my[nodeSymbol] : my;
+    return this[componentMetaSymbol].checkNestingDown(curNode as any, target[nodeSymbol] || target);
   }
 }

--- a/packages/shell/src/document-model.ts
+++ b/packages/shell/src/document-model.ts
@@ -6,7 +6,13 @@ import {
   IOnChangeOptions as InnerIOnChangeOptions,
   PropChangeOptions as InnerPropChangeOptions,
 } from '@alilc/lowcode-designer';
-import { TransformStage, RootSchema, NodeSchema, NodeData, GlobalEvent } from '@alilc/lowcode-types';
+import {
+  TransformStage,
+  RootSchema,
+  NodeSchema,
+  NodeData,
+  GlobalEvent,
+} from '@alilc/lowcode-types';
 import Node from './node';
 import Selection from './selection';
 import Detecting from './detecting';
@@ -33,6 +39,7 @@ type PropChangeOptions = {
 export default class DocumentModel {
   private readonly [documentSymbol]: InnerDocumentModel;
   private readonly [editorSymbol]: Editor;
+  private _focusNode: Node;
   public selection: Selection;
   public detecting: Detecting;
   public history: History;
@@ -45,6 +52,8 @@ export default class DocumentModel {
     this.detecting = new Detecting(document);
     this.history = new History(document.getHistory());
     this.canvas = new Canvas(document.designer);
+
+    this._focusNode = Node.create(this[documentSymbol].focusNode);
   }
 
   static create(document: InnerDocumentModel | undefined | null) {
@@ -68,6 +77,14 @@ export default class DocumentModel {
     return Node.create(this[documentSymbol].getRoot());
   }
 
+  get focusNode(): Node {
+    return this._focusNode;
+  }
+
+  set focusNode(node: Node) {
+    this._focusNode = node;
+  }
+
   /**
    * 获取文档下所有节点
    * @returns
@@ -85,6 +102,11 @@ export default class DocumentModel {
    */
   get modalNodesManager() {
     return ModalNodesManager.create(this[documentSymbol].modalNodesManager);
+  }
+
+  // @TODO: 不能直接暴露
+  get dropLocation() {
+    return this[documentSymbol].dropLocation;
   }
 
   /**
@@ -157,7 +179,7 @@ export default class DocumentModel {
    * 当前 document 新增节点事件
    */
   onAddNode(fn: (node: Node) => void) {
-    this[documentSymbol].onNodeCreate((node: InnerNode) => {
+    return this[documentSymbol].onNodeCreate((node: InnerNode) => {
       fn(Node.create(node)!);
     });
   }
@@ -166,7 +188,7 @@ export default class DocumentModel {
    * 当前 document 删除节点事件
    */
   onRemoveNode(fn: (node: Node) => void) {
-    this[documentSymbol].onNodeDestroy((node: InnerNode) => {
+    return this[documentSymbol].onNodeDestroy((node: InnerNode) => {
       fn(Node.create(node)!);
     });
   }

--- a/packages/shell/src/dragon.ts
+++ b/packages/shell/src/dragon.ts
@@ -17,6 +17,13 @@ export default class Dragon {
   }
 
   /**
+   * is dragging or not
+   */
+  get dragging() {
+    return this[dragonSymbol].dragging;
+  }
+
+  /**
    * 绑定 dragstart 事件
    * @param func
    * @returns

--- a/packages/shell/src/event.ts
+++ b/packages/shell/src/event.ts
@@ -61,6 +61,15 @@ export default class Event {
     }
     this[editorSymbol].emit(`${this.options.prefix}:${event}`, ...args);
   }
+
+  /**
+   * DO NOT USE if u fully understand what this method does.
+   * @param event
+   * @param args
+   */
+  __internalEmit__(event: string, ...args: unknown[]) {
+    this[editorSymbol].emit(event, ...args);
+  }
 }
 
 export function getEvent(editor: InnerEditor, options: any = { prefix: 'common' }) {

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -5,6 +5,7 @@ import Event, { getEvent } from './event';
 import History from './history';
 import Material from './material';
 import Node from './node';
+import NodeChildren from './node-children';
 import Project from './project';
 import Prop from './prop';
 import Selection from './selection';
@@ -13,6 +14,7 @@ import Hotkey from './hotkey';
 import Skeleton from './skeleton';
 import Dragon from './dragon';
 import SettingPropEntry from './setting-prop-entry';
+import SettingTopEntry from './setting-top-entry';
 export * from './symbols';
 
 /**
@@ -30,6 +32,7 @@ export {
   History,
   Material,
   Node,
+  NodeChildren,
   Project,
   Prop,
   Selection,
@@ -37,6 +40,7 @@ export {
   Hotkey,
   Skeleton,
   SettingPropEntry,
+  SettingTopEntry,
   Dragon,
   getEvent,
 };

--- a/packages/shell/src/material.ts
+++ b/packages/shell/src/material.ts
@@ -7,9 +7,10 @@ import {
   addBuiltinComponentAction,
   removeBuiltinComponentAction,
   modifyBuiltinComponentAction,
+  isComponentMeta,
 } from '@alilc/lowcode-designer';
 import { AssetsJson } from '@alilc/lowcode-utils';
-import { ComponentAction } from '@alilc/lowcode-types';
+import { ComponentAction, ComponentMetadata } from '@alilc/lowcode-types';
 import { editorSymbol, designerSymbol } from './symbols';
 import ComponentMeta from './component-meta';
 
@@ -85,6 +86,26 @@ export default class Material {
   getComponentMeta(componentName: string) {
     return ComponentMeta.create(this[designerSymbol].getComponentMeta(componentName));
   }
+
+  /**
+   * create an instance of ComponentMeta by given metadata
+   * @param metadata
+   * @returns
+   */
+  createComponentMeta(metadata: ComponentMetadata) {
+    return ComponentMeta.create(this[designerSymbol].createComponentMeta(metadata));
+  }
+
+  /**
+   * test if the given object is a ComponentMeta instance or not
+   * @param obj
+   * @returns
+   */
+  isComponentMeta(obj: any) {
+    return isComponentMeta(obj);
+  }
+
+
 
   /**
    * 获取所有已注册的物料元数据

--- a/packages/shell/src/node-children.ts
+++ b/packages/shell/src/node-children.ts
@@ -38,6 +38,13 @@ export default class NodeChildren {
   }
 
   /**
+   * judge if it is not empty
+   */
+  get notEmpty() {
+    return !this.isEmpty;
+  }
+
+  /**
    * 删除指定节点
    * @param node
    * @returns
@@ -81,7 +88,7 @@ export default class NodeChildren {
    * @returns
    */
   get(index: number) {
-    return this[nodeChildrenSymbol].get(index);
+    return Node.create(this[nodeChildrenSymbol].get(index));
   }
 
   /**

--- a/packages/shell/src/node.ts
+++ b/packages/shell/src/node.ts
@@ -17,9 +17,13 @@ export default class Node {
   private readonly [documentSymbol]: InnerDocumentModel;
   private readonly [nodeSymbol]: InnerNode;
 
+  private _id: string;
+
   constructor(node: InnerNode) {
     this[nodeSymbol] = node;
     this[documentSymbol] = node.document;
+
+    this._id = this[nodeSymbol].id;
   }
 
   static create(node: InnerNode | null | undefined) {
@@ -36,7 +40,14 @@ export default class Node {
    * 节点 id
    */
   get id() {
-    return this[nodeSymbol].id;
+    return this._id;
+  }
+
+  /**
+   * set id
+   */
+  set id(id: string) {
+    this._id = id;
   }
 
   /**
@@ -84,7 +95,7 @@ export default class Node {
   /**
    * 是否为「模态框」节点
    */
-   get isModal() {
+  get isModal() {
     return this[nodeSymbol].isModal();
   }
 
@@ -107,6 +118,13 @@ export default class Node {
    */
   get isLeaf() {
     return this[nodeSymbol].isLeaf();
+  }
+
+  /**
+   * judge if it is a node or not
+   */
+  get isNode() {
+    return true;
   }
 
   /**
@@ -208,8 +226,15 @@ export default class Node {
   /**
    * 返回节点的属性集
    */
-   get propsData() {
+  get propsData() {
     return this[nodeSymbol].propsData;
+  }
+
+  /**
+   * 获取符合搭建协议-节点 schema 结构
+   */
+  get schema(): any {
+    return this[nodeSymbol].schema;
   }
 
   /**
@@ -258,11 +283,23 @@ export default class Node {
     return this[nodeSymbol].hasLoop();
   }
 
+  getVisible() {
+    return this[nodeSymbol].getVisible();
+  }
+
+  isConditionalVisible() {
+    return this[nodeSymbol].isConditionalVisible();
+  }
+
   /**
    * @deprecated use .props instead
    */
   getProps() {
     return this.props;
+  }
+
+  contains(node: Node) {
+    return this[nodeSymbol].contains(node[nodeSymbol]);
   }
 
   /**

--- a/packages/shell/src/prop.ts
+++ b/packages/shell/src/prop.ts
@@ -44,6 +44,11 @@ export default class Prop {
   }
 
   /**
+   * judge if it is a prop or not
+   */
+  get isProp() { return true; }
+
+  /**
    * 设置值
    * @param val
    */

--- a/packages/shell/src/selection.ts
+++ b/packages/shell/src/selection.ts
@@ -23,6 +23,13 @@ export default class Selection {
   }
 
   /**
+   * return selected Node instance
+   */
+  get node() {
+    return this.getNodes()[0];
+  }
+
+  /**
    * 选中指定节点（覆盖方式）
    * @param id
    */

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@alilc/lowcode-datasource-types": "^1.0.0",
-    "react": "^16.9 || ^17",
+    "react": "^16.9",
     "strict-event-emitter-types": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -102,6 +102,6 @@ export function invariant(check: any, message: string, thing?: any) {
 
 export function deprecate(fail: any, message: string, alterative?: string) {
   if (fail) {
-    console.warn(`Deprecation: ${message}` + (alterative ? `, use ${alterative} instead.'` : ''));
+    console.warn(`Deprecation: ${message}` + (alterative ? `, use ${alterative} instead.` : ''));
   }
 }


### PR DESCRIPTION
- feat: 支持自定义插件 context，通过新增 enhancePluginContextHook 配置项
- feat: 支持插件通过 register 的 options 来传递插件参数
- feat: 导出部分类和 symbols，支持高级场景对类的能力增强 / 兼容（非十分熟悉引擎功能切勿使用！）
- feat: 补充 ComponentMeta / Node / NodeChildren 等类的必要方法，比如：checkNestingUp / checkNestingDown
- refactor: host 中使用 childWhitelist 而非原来的 canDropIn
- refactor: 兼容老版本的插件 pluginName 和 dep 的声明（新版不推荐使用！）
- refactor: 桥接 engineConfig.set 和内部使用的 editor.set 功能
- refactor: 修改 deprecate 方法
- fix: 修复在调试拖拽时，事件属性缺失导致报错
- fix: 修复在大纲树点击模态框节点时，交互异常