### PR TITLE
fix: fix setter hooks error

### DIFF
--- a/packages/designer/src/designer/setting/utils.ts
+++ b/packages/designer/src/designer/setting/utils.ts
@@ -1,8 +1,8 @@
 // all this file for polyfill vision logic
-
 import { isValidElement } from 'react';
-import { isSetterConfig, isDynamicSetter } from '@alilc/lowcode-types';
+import { isSetterConfig, isDynamicSetter, FieldConfig, SetterConfig } from '@alilc/lowcode-types';
 import { getSetter } from '@alilc/lowcode-editor-core';
+import { SettingField } from './setting-field';
 
 function getHotterFromSetter(setter) {
   return setter && (setter.Hotter || (setter.type && setter.type.Hotter)) || []; // eslint-disable-line
@@ -35,7 +35,7 @@ export class Transducer {
 
   context: any;
 
-  constructor(context, config) {
+  constructor(context: SettingField, config: { setter: FieldConfig['setter'] }) {
     let { setter } = config;
 
     // 1. validElement
@@ -46,16 +46,29 @@ export class Transducer {
     } else if (isValidElement(setter) && setter.type.displayName === 'MixedSetter') {
       setter = setter.props?.setters?.[0];
     } else if (typeof setter === 'object' && setter.componentName === 'MixedSetter') {
-      setter = setter && setter.props && setter.props.setters && Array.isArray(setter.props.setters) && setter.props.setters[0];
+      setter = Array.isArray(setter?.props?.setters) && setter.props.setters[0];
     }
 
+    /**
+     * 两种方式标识是 FC 而不是动态 setter
+     * 1. 物料描述里面 setter 的配置，显式设置为 false
+     * 2. registerSetter 注册 setter 时显式设置为 false
+     */
+
+    let isDynamic = true;
+
     if (isSetterConfig(setter)) {
-      setter = setter.componentName;
+      const { componentName, isDynamic: dynamicFlag } = setter as SetterConfig;
+      setter = componentName;
+      isDynamic = dynamicFlag !== false;
     }
     if (typeof setter === 'string') {
-      setter = getSetter(setter)?.component;
+      const { component, isDynamic: dynamicFlag } = getSetter(setter) || {};
+      setter = component;
+      // 如果在物料配置中声明了，在 registerSetter 没有声明，取物料配置中的声明
+      isDynamic = dynamicFlag === undefined ? isDynamic : dynamicFlag !== false;
     }
-    if (isDynamicSetter(setter)) {
+    if (isDynamicSetter(setter) && isDynamic) {
       setter = setter.call(context, context);
     }
 

--- a/packages/editor-core/src/di/setter.ts
+++ b/packages/editor-core/src/di/setter.ts
@@ -15,6 +15,8 @@ export type RegisteredSetter = {
    */
   initialValue?: any | ((field: any) => any);
   recommend?: boolean;
+  // 标识是否为动态setter，默认为true
+  isDynamic?: boolean;
 };
 const settersMap = new Map<string, RegisteredSetter & {
   type: string;

--- a/packages/types/src/setter-config.ts
+++ b/packages/types/src/setter-config.ts
@@ -63,6 +63,8 @@ export interface SetterConfig {
    * @todo 物料协议推进
    */
   valueType?: CompositeValue[];
+  // 标识是否为动态setter，默认为true
+  isDynamic?: boolean;
 }
 
 // if *string* passed must be a registered Setter Name, future support blockSchema


### PR DESCRIPTION
修复开发 setter 使用 hooks 的错误。

使用一个 `isDynamic` 属性来进行标识是否为动态 setter，为了向下兼容，这个值默认为 true，所以 FC 需要显式设置为 false。

可以通过以下两种方式去设置 `isDynamic`：
1. 物料描述的 setter 配置项设置 `isDynamic` 为 false
2. 注册 setter 时设置 `isDynamic` 为 false，如下图所示：
<img width="591" alt="image" src="https://user-images.githubusercontent.com/8730698/169211693-751c0ceb-9763-414e-a829-4c4bd771e2de.png">


