### PR TITLE
fix: 🐛 修复数据源引擎请求处理器映射严格模式下被过滤的问题

### DIFF
--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -118,6 +118,10 @@ const VALID_ENGINE_OPTIONS = {
     type: 'array',
     description: '自定义 simulatorUrl 的地址',
   },
+  requestHandlersMap: {
+    type: 'object',
+    description: '数据源引擎的请求处理器映射',
+  },
 };
 export interface EngineOptions {
   /**
@@ -227,6 +231,9 @@ export interface EngineOptions {
     constants?: Record<string, any>;
   };
 
+  /**
+   * 数据源引擎的请求处理器映射
+   */
   requestHandlersMap: RequestHandlersMap;
 }
 
@@ -316,7 +323,7 @@ export class EngineConfig {
         if (isValidKey(key)) {
           this.set(key, engineOptions[key]);
         } else {
-          logger.warn(`failed to config ${key} to engineConfig, only predefined options can be set under strict mode, predefined options: ${VALID_ENGINE_OPTIONS}`);
+          logger.warn(`failed to config ${key} to engineConfig, only predefined options can be set under strict mode, predefined options: `, VALID_ENGINE_OPTIONS);
         }
       });
     } else {


### PR DESCRIPTION
严格模式存在过滤，将数据源引擎请求处理器映射加到了 VALID_ENGINE_OPTIONS 中

```js
const isValidKey = (key: string) => {
    const result = (VALID_ENGINE_OPTIONS as any)[key];
    return !(result === undefined || result === null);
  };
```