### PR TITLE
feat: add isGroup & items to shell SettingPropEntry

### DIFF
--- a/packages/shell/src/setting-prop-entry.ts
+++ b/packages/shell/src/setting-prop-entry.ts
@@ -1,5 +1,5 @@
 import { SettingField, ISetValueOptions } from '@alilc/lowcode-designer';
-import { CompositeValue, FieldConfig } from '@alilc/lowcode-types';
+import { CompositeValue, FieldConfig, CustomView, isCustomView } from '@alilc/lowcode-types';
 import { settingPropEntrySymbol } from './symbols';
 import Node from './node';
 import SettingTopEntry from './setting-top-entry';
@@ -14,6 +14,13 @@ export default class SettingPropEntry {
 
   static create(prop: SettingField) {
     return new SettingPropEntry(prop);
+  }
+
+  /**
+   * 获取设置属性的 isGroup
+   */
+  get isGroup() {
+    return this[settingPropEntrySymbol].isGroup;
   }
 
   /**
@@ -95,6 +102,18 @@ export default class SettingPropEntry {
    */
   get componentMeta(): ComponentMeta | null {
     return ComponentMeta.create(this[settingPropEntrySymbol].componentMeta);
+  }
+
+  /**
+   * 获取设置属性的 items
+   */
+  get items(): Array<SettingPropEntry | CustomView> {
+    return this[settingPropEntrySymbol].items?.map((item) => {
+      if (isCustomView(item)) {
+        return item;
+      }
+      return item.internalToShellPropEntry();
+    });
   }
 
   /**


### PR DESCRIPTION
lowcode-engine-ext 的 object-setter 会调用 [field.createField](https://github.com/alibaba/lowcode-engine-ext/blob/b4a9d008c3/src/setter/object-setter/index.tsx#L215) 来创建 field，然后调用 [createSettingFieldView](https://github.com/alibaba/lowcode-engine-ext/blob/b4a9d008c3/src/setter/object-setter/index.tsx#L228) 来创建 settingFieldView。createSettingFieldView 会读取 [item.isGroup](https://github.com/alibaba/lowcode-engine/blob/44ad744aac/packages/editor-skeleton/src/components/settings/settings-pane.tsx#L278) 来判断是否使用 SettingGroupView。SettingGroupView 又会使用 [field.items](https://github.com/alibaba/lowcode-engine/blob/44ad744aac/packages/editor-skeleton/src/components/settings/settings-pane.tsx#L271) 遍历创建 fieldView

所以 shell 的 SettingPropEntry 要提供访问 isGroup 和 items 这两个变量，否则通过 field.createField 都读不到这些值，会影响后续的逻辑