### PR TITLE
fix: addon-combine affect metadata unexpectedly

### DIFF
--- a/packages/editor-skeleton/src/transducers/addon-combine.ts
+++ b/packages/editor-skeleton/src/transducers/addon-combine.ts
@@ -87,7 +87,7 @@ export default function (metadata: TransformedComponentMetadata): TransformedCom
     });
   }
   //  通用设置
-  let propsGroup = props || [];
+  let propsGroup = props ? [...props] : [];
   const basicInfo: any = {};
   if (componentName === 'Slot') {
     if (!configure.component) {


### PR DESCRIPTION
如果按照原来讨论的，直接在 metadata.configure 上挂的话，经过测试，还是不能影响整个的 metadata。猜测是进到这个函数里的 metadata 已经是被复制过了，所以又改回了之前的方案，这个方案经过测试可以使用。