### PR TITLE
fix: npm run clean error in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "./scripts/build.sh",
     "build:npm": "lerna run build --stream",
     "build:umd": "lerna run build:umd --stream",
-    "clean": "rm -rf ./packages/*/lib ./packages/*/es ./packages/*/dist ./packages/*/build",
+    "clean": "rimraf ./packages/*/lib ./packages/*/es ./packages/*/dist ./packages/*/build",
+    "clean:lib": "rimraf ./node_modules",
     "lint": "f2elint scan -q -i ./packages/*/src",
     "lint:fix": "f2elint fix -i ./packages/*/src",
     "lint:modules": "f2elint scan -q -i ./modules/*/src",
@@ -45,7 +46,8 @@
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
     "typescript": "^4.5.5",
-    "yarn": "^1.22.17"
+    "yarn": "^1.22.17",
+    "rimraf": "^3.0.2"
   },
   "engines": {
     "node": ">=14.17.0 <16"


### PR DESCRIPTION
不管在powershell或者cmd里面 rm -rf 都会报错。使用这个第三方包 rimraf, 本地测试成功。