### PR TITLE
feat: added thisRequiredInJSE API to control whether JSExpression exp…

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -228,6 +228,10 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
     return this.get('requestHandlersMap') || null;
   }
 
+  get thisRequiredInJSE(): any {
+    return engineConfig.get('thisRequiredInJSE') ?? true;
+  }
+
   @computed get componentsAsset(): Asset | undefined {
     return this.get('componentsAsset');
   }

--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -133,6 +133,10 @@ const VALID_ENGINE_OPTIONS = {
     type: 'object',
     description: '数据源引擎的请求处理器映射',
   },
+  thisRequiredInJSE: {
+    type: 'boolean',
+    description: 'JSExpression 是否只支持使用 this 来访问上下文变量',
+  },
 };
 export interface EngineOptions {
   /**
@@ -248,6 +252,12 @@ export interface EngineOptions {
    * 数据源引擎的请求处理器映射
    */
   requestHandlersMap?: RequestHandlersMap;
+
+  /**
+   * @default true
+   * JSExpression 是否只支持使用 this 来访问上下文变量，假如需要兼容原来的 'state.xxx'，则设置为 false
+   */
+  thisRequiredInJSE?: boolean;
 }
 
 const getStrictModeValue = (engineOptions: EngineOptions, defaultValue: boolean): boolean => {

--- a/packages/rax-simulator-renderer/src/renderer-view.tsx
+++ b/packages/rax-simulator-renderer/src/renderer-view.tsx
@@ -219,6 +219,7 @@ class Renderer extends Component<{
         onCompGetRef={(schema: any, ref: any) => {
           documentInstance.mountInstance(schema.id, ref);
         }}
+        thisRequiredInJSE={host.thisRequiredInJSE}
         documentId={document.id}
         getNode={(id: string) => documentInstance.getNode(id) as any}
         rendererName="PageRenderer"

--- a/packages/react-simulator-renderer/src/renderer-view.tsx
+++ b/packages/react-simulator-renderer/src/renderer-view.tsx
@@ -189,6 +189,7 @@ class Renderer extends Component<{
         setSchemaChangedSymbol={this.setSchemaChangedSymbol}
         getNode={(id: string) => documentInstance.getNode(id) as Node}
         rendererName="PageRenderer"
+        thisRequiredInJSE={host.thisRequiredInJSE}
         customCreateElement={(Component: any, props: any, children: any) => {
           const { __id, ...viewProps } = props;
           viewProps.componentId = __id;

--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -12,6 +12,7 @@ import {
   getValue,
   parseData,
   parseExpression,
+  parseThisRequiredExpression,
   parseI18n,
   isEmpty,
   isSchema,
@@ -83,11 +84,13 @@ export default function baseRendererFactory(): IBaseRenderComponent {
     getLocale: any;
     setLocale: any;
     styleElement: any;
+    parseExpression: any;
     [key: string]: any;
 
     constructor(props: IBaseRendererProps, context: IBaseRendererContext) {
       super(props, context);
       this.context = context;
+      this.parseExpression = props?.thisRequiredInJSE ? parseThisRequiredExpression : parseExpression;
       this.__beforeInit(props);
       this.__init(props);
       this.__afterInit(props);
@@ -112,7 +115,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
 
       if (func) {
         if (isJSExpression(func) || isJSFunction(func)) {
-          const fn = parseExpression(func, this);
+          const fn = props.thisRequiredInJSE ? parseThisRequiredExpression(func, this) : parseExpression(func, this);
           return fn(props, state);
         }
 
@@ -193,7 +196,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
       if (fn) {
         // TODO, cache
         if (isJSExpression(fn) || isJSFunction(fn)) {
-          fn = parseExpression(fn, this);
+          fn = this.parseExpression(fn, this);
         }
         if (typeof fn !== 'function') {
           console.error(`生命周期${method}类型不符`, fn);
@@ -219,7 +222,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
       this.__customMethodsList = customMethodsList;
       forEach(__schema.methods, (val: any, key: string) => {
         if (isJSExpression(val) || isJSFunction(val)) {
-          val = parseExpression(val, this);
+          val = this.parseExpression(val, this);
         }
         if (typeof val !== 'function') {
           console.error(`自定义函数${key}类型不符`, val);
@@ -414,7 +417,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
         const { __appHelper: appHelper, __components: components = {} } = this.props || {};
 
         if (isJSExpression(schema)) {
-          return parseExpression(schema, scope);
+          return this.parseExpression(schema, scope);
         }
         if (isI18nData(schema)) {
           return parseI18n(schema, scope);
@@ -434,7 +437,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
         const _children = this.getSchemaChildren(schema);
         // 解析占位组件
         if (schema?.componentName === 'Fragment' && _children) {
-          const tarChildren = isJSExpression(_children) ? parseExpression(_children, scope) : _children;
+          const tarChildren = isJSExpression(_children) ? this.parseExpression(_children, scope) : _children;
           return this.__createVirtualDom(tarChildren, scope, parentInfo);
         }
 
@@ -496,7 +499,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
         let scopeKey = '';
         // 判断组件是否需要生成scope，且只生成一次，挂在this.__compScopes上
         if (Comp.generateScope) {
-          const key = parseExpression(schema.props?.key, scope);
+          const key = this.parseExpression(schema.props?.key, scope);
           if (key) {
             // 如果组件自己设置key则使用组件自己的key
             scopeKey = key;
@@ -647,7 +650,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
 
         _children.forEach((_child: any) => {
           const _childVirtualDom = this.__createVirtualDom(
-            isJSExpression(_child) ? parseExpression(_child, scope) : _child,
+            isJSExpression(_child) ? this.parseExpression(_child, scope) : _child,
             scope,
             {
               schema,
@@ -754,7 +757,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
         return checkProps(props);
       }
       if (isJSExpression(props)) {
-        props = parseExpression(props, scope);
+        props = this.parseExpression(props, scope);
         // 只有当变量解析出来为模型结构的时候才会继续解析
         if (!isSchema(props) && !isJSSlot(props)) return checkProps(props);
       }

--- a/packages/renderer-core/src/renderer/renderer.tsx
+++ b/packages/renderer-core/src/renderer/renderer.tsx
@@ -60,6 +60,7 @@ export default function rendererFactory(): IRenderComponent {
       schema: {} as RootSchema,
       onCompGetRef: () => { },
       onCompGetCtx: () => { },
+      thisRequiredInJSE: true,
     };
 
     static findDOMNode = findDOMNode;

--- a/packages/renderer-core/src/types/index.ts
+++ b/packages/renderer-core/src/types/index.ts
@@ -128,6 +128,11 @@ export interface IRendererProps {
   faultComponent?: IGeneralComponent;
   /** 设备信息 */
   device?: string;
+  /**
+   * @default true
+   * JSExpression 是否只支持使用 this 来访问上下文变量
+   */
+  thisRequiredInJSE?: boolean;
 }
 
 export interface IRendererState {
@@ -148,12 +153,13 @@ export interface IBaseRendererProps {
   __host?: BuiltinSimulatorHost;
   __container?: any;
   config?: Record<string, any>;
-  designMode?: 'live' | 'design';
+  designMode?: 'design';
   className?: string;
   style?: CSSProperties;
   id?: string | number;
   getSchemaChangedSymbol?: () => boolean;
   setSchemaChangedSymbol?: (symbol: boolean) => void;
+  thisRequiredInJSE?: boolean;
   documentId?: string;
   getNode?: any;
   /**

--- a/packages/renderer-core/src/utils/common.ts
+++ b/packages/renderer-core/src/utils/common.ts
@@ -242,7 +242,7 @@ export function transformStringToFunction(str: string) {
  * @param self scope object
  * @returns funtion
  */
-export function parseExpression(str: any, self: any) {
+export function parseExpression(str: any, self: any, thisRequired = false) {
   try {
     const contextArr = ['"use strict";', 'var __self = arguments[0];'];
     contextArr.push('return ');
@@ -259,12 +259,16 @@ export function parseExpression(str: any, self: any) {
     if (inSameDomain() && (window.parent as any).__newFunc) {
       return (window.parent as any).__newFunc(tarStr)(self);
     }
-    const code = `with($scope || {}) { ${tarStr} }`;
+    const code = `with(${thisRequired ? '{}' : '$scope || {}'}) { ${tarStr} }`;
     return new Function('$scope', code)(self);
   } catch (err) {
-    logger.error('parseExpression.error', err, str, self);
+    logger.error('parseExpression.error', err, str, self?.__self ?? self);
     return undefined;
   }
+}
+
+export function parseThisRequiredExpression(str: any, self: any) {
+  return parseExpression(str, self, true);
 }
 
 /**

--- a/packages/renderer-core/tests/renderer/__snapshots__/renderer.test.tsx.snap
+++ b/packages/renderer-core/tests/renderer/__snapshots__/renderer.test.tsx.snap
@@ -994,6 +994,24 @@ exports[`JSExpression JSExpression props with loop 1`] = `
 </div>
 `;
 
+exports[`JSExpression JSExpression props with loop, and thisRequiredInJSE is true 1`] = `
+<div
+  className="lce-page"
+  style={Object {}}
+>
+  <div
+    className="div-ut"
+    forwardRef={[Function]}
+    name1="1"
+  />
+  <div
+    className="div-ut"
+    forwardRef={[Function]}
+    name1="2"
+  />
+</div>
+`;
+
 exports[`JSExpression JSFunction props 1`] = `
 <div
   className="lce-page"

--- a/packages/renderer-core/tests/renderer/renderer.test.tsx
+++ b/packages/renderer-core/tests/renderer/renderer.test.tsx
@@ -145,12 +145,58 @@ describe('JSExpression', () => {
       ]
     };
 
-    getComp(schema, components.Div).then(({ component, inst }) => {
+    getComp(schema, components.Div, {
+      thisRequiredInJSE: false,
+    }).then(({ component, inst }) => {
       // expect(inst[0].props.visible).toBeTruthy();
       expect(inst.length).toEqual(2);
       [1, 2].forEach((i) => {
         expect(inst[0].props[`name${i}`]).toBe('1');
         expect(inst[1].props[`name${i}`]).toBe('2');
+      })
+      componentSnapshot = component;
+      done();
+    });
+  });
+
+  it('JSExpression props with loop, and thisRequiredInJSE is true', (done) => {
+    const schema = {
+      componentName: 'Page',
+      props: {},
+      state: {
+        isShowDialog: true,
+      },
+      children: [
+        {
+          componentName: "Div",
+          loop: [
+            {
+              name: '1',
+            },
+            {
+              name: '2'
+            }
+          ],
+          props: {
+            className: "div-ut",
+            name1: {
+              type: 'JSExpression',
+              value: 'this.item.name',
+            },
+            name2: {
+              type: 'JSExpression',
+              value: 'item.name',
+            },
+          }
+        }
+      ]
+    };
+
+    getComp(schema, components.Div).then(({ component, inst }) => {
+      expect(inst.length).toEqual(2);
+      [0, 1].forEach((i) => {
+        expect(inst[i].props[`name1`]).toBe(i + 1 + '');
+        expect(inst[i].props[`name2`]).toBe(undefined);
       })
       componentSnapshot = component;
       done();


### PR DESCRIPTION
Added thisRequiredInJSE API to control whether JSExpression expression access context must use this.

![image](https://user-images.githubusercontent.com/11935995/174937075-0e9ac6a9-96d6-427f-af0a-31283ebc9197.png)

在 JSExpression 是需要通过 this 来获取上下文，但是由于之前实现的方式可以不通过 this 来获取上下文，也就是可以通过 state.text 来访问，而不是通过 this.state.text。

这样一方面导致 schema 在出码之后会出现问题，另外一方面和协议也不一致。

为了兼容历史场景，新增 thisRequiredInJSE API，如果需要通过 state.text 的方式来访问可以配置其为 false。仅支持运行时渲染场景，出码场景不支持。