### PR TITLE
feat: pass e to customizeIgnoreSelectors

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -618,7 +618,7 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
           '.next-calendar-table',
           '.editor-container', // 富文本组件
         ];
-        const ignoreSelectors = customizeIgnoreSelectors?.(defaultIgnoreSelectors) || defaultIgnoreSelectors;
+        const ignoreSelectors = customizeIgnoreSelectors?.(defaultIgnoreSelectors, e) || defaultIgnoreSelectors;
         const ignoreSelectorsString = ignoreSelectors.join(',');
         // 提供了 customizeIgnoreSelectors 的情况下，忽略 isFormEvent() 判断
         if ((!customizeIgnoreSelectors && isFormEvent(e)) || target?.closest(ignoreSelectorsString)) {

--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -73,7 +73,7 @@ const VALID_ENGINE_OPTIONS = {
   customizeIgnoreSelectors: {
     type: 'function',
     default: undefined,
-    description: '定制画布中点击被忽略的 selectors, eg. (defaultIgnoreSelectors: string[]) => string[]',
+    description: '定制画布中点击被忽略的 selectors, eg. (defaultIgnoreSelectors: string[], e: MouseEvent) => string[]',
   },
   disableDefaultSettingPanel: {
     type: 'boolean',
@@ -192,7 +192,7 @@ export interface EngineOptions {
   /**
    * 定制画布中点击被忽略的 selectors，默认值：undefined
    */
-  customizeIgnoreSelectors?: (defaultIgnoreSelectors: string[]) => string[];
+  customizeIgnoreSelectors?: (defaultIgnoreSelectors: string[], e: MouseEvent) => string[];
   /**
    * 禁止默认的设置面板，默认值：false
    */


### PR DESCRIPTION
So that the `customizeIgnoreSelectors` can dynamically decide whether the target of the event can respond to the event.