### PR TITLE
fix: designer/loadIncrementalAssets await Sequential

### DIFF
--- a/packages/designer/src/designer/designer.ts
+++ b/packages/designer/src/designer/designer.ts
@@ -403,8 +403,8 @@ export class Designer {
       // 合并assets
       let assets = this.editor.get('assets');
       let newAssets = megreAssets(assets, incrementalAssets);
-      // 对于 assets 存在需要二次网络下载的过程，必须 await 等待结束之后，再进行事件触发，不然实际事件会比物料导入更快
-      await this.editor.setAssets(newAssets);
+      // 对于 assets 存在需要二次网络下载的过程，必须 await 等待结束之后，再进行事件触发
+      await this.editor.set('assets', newAssets);
     }
     // TODO: 因为涉及修改 prototype.view，之后在 renderer 里修改了 vc 的 view 获取逻辑后，可删除
     this.refreshComponentMetasMap();

--- a/packages/designer/src/designer/designer.ts
+++ b/packages/designer/src/designer/designer.ts
@@ -403,7 +403,8 @@ export class Designer {
       // 合并assets
       let assets = this.editor.get('assets');
       let newAssets = megreAssets(assets, incrementalAssets);
-      this.editor.set('assets', newAssets);
+      // 对于 assets 存在需要二次网络下载的过程，必须 await 等待结束之后，再进行事件触发，不然实际事件会比物料导入更快
+      await this.editor.setAssets(newAssets);
     }
     // TODO: 因为涉及修改 prototype.view，之后在 renderer 里修改了 vc 的 view 获取逻辑后，可删除
     this.refreshComponentMetasMap();

--- a/packages/editor-core/src/editor.ts
+++ b/packages/editor-core/src/editor.ts
@@ -76,10 +76,9 @@ export class Editor extends (EventEmitter as any) implements IEditor {
     return this.context.has(keyOrType);
   }
 
-  set(key: KeyType, data: any): void {
+  set(key: KeyType, data: any): void | Promise<void>  {
     if (key === 'assets') {
-      this.setAssets(data);
-      return;
+      return this.setAssets(data);
     }
     // store the data to engineConfig while invoking editor.set()
     if (!keyBlacklist.includes(key as string)) {

--- a/packages/types/src/editor.ts
+++ b/packages/types/src/editor.ts
@@ -40,9 +40,7 @@ export interface IEditor extends StrictEventEmitter<EventEmitter, GlobalEvent.Ev
 
   has: (keyOrType: KeyType) => boolean;
 
-  set: (key: KeyType, data: any) => void;
-  
-  setAssets: (data: any) => Promise<void>;
+  set: (key: KeyType, data: any) => void | Promise<void>;
 
   onceGot: <T = undefined, KeyOrType extends KeyType = any>
     (keyOrType: KeyOrType) => Promise<GetReturnType<T, KeyOrType>>;

--- a/packages/types/src/editor.ts
+++ b/packages/types/src/editor.ts
@@ -41,6 +41,8 @@ export interface IEditor extends StrictEventEmitter<EventEmitter, GlobalEvent.Ev
   has: (keyOrType: KeyType) => boolean;
 
   set: (key: KeyType, data: any) => void;
+  
+  setAssets: (data: any) => Promise<void>;
 
   onceGot: <T = undefined, KeyOrType extends KeyType = any>
     (keyOrType: KeyOrType) => Promise<GetReturnType<T, KeyOrType>>;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15883471/180164555-4ec2a172-f3cd-456b-b4a1-a6f68dca4913.png)

在部分物料组件异步追加物料时，若触发 assetLoader ，代码执行时序错乱