### PR TITLE
feat(designer): modify the load order of the simulator

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -399,15 +399,15 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
       assetBundle(this.get('extraEnvironment'), AssetLevel.Environment),
 
       // required & use once
-      assetBundle(libraryAsset, AssetLevel.Library),
-      // required & TODO: think of update
-      assetBundle(this.theme, AssetLevel.Theme),
-      // required & use once
       assetBundle(
         this.get('simulatorUrl') ||
           (this.renderEnv === 'rax' ? defaultRaxSimulatorUrl : defaultSimulatorUrl),
         AssetLevel.Runtime,
       ),
+      // required & use once
+      assetBundle(libraryAsset, AssetLevel.Library),
+      // required & TODO: think of update
+      assetBundle(this.theme, AssetLevel.Theme),
     ];
 
     // wait 准备 iframe 内容、依赖库注入


### PR DESCRIPTION
修改 simulator 加载顺序，将其放在资源加载之前。

### 原因

在加载画布本身的同时，可能还需要加载一些框架运行时，比如 vue 的运行时，而一些资源加载的时候（比如 vue 组件库），是需依赖于 vue 运行时的，故而将 simulator 加载提前
