### PR TITLE
fix: delete unused typescript types

### DIFF
--- a/packages/utils/src/asset.ts
+++ b/packages/utils/src/asset.ts
@@ -1,10 +1,11 @@
-import { AssetItem, AssetType, AssetLevels, Asset, AssetList, AssetBundle, AssetLevel, AssetsJson } from '@alilc/lowcode-types';
+import { AssetType, AssetLevels, AssetLevel } from '@alilc/lowcode-types';
+import type { AssetItem, Asset, AssetList, AssetBundle, AssetsJson } from '@alilc/lowcode-types';
 import { isCSSUrl } from './is-css-url';
 import { createDefer } from './create-defer';
 import { load, evaluate } from './script';
 
 // API 向下兼容
-export { AssetItem, AssetType, AssetLevels, Asset, AssetList, AssetBundle, AssetLevel, AssetsJson } from '@alilc/lowcode-types';
+export { AssetType, AssetLevels, AssetLevel } from '@alilc/lowcode-types';
 
 export function isAssetItem(obj: any): obj is AssetItem {
   return obj && obj.type;


### PR DESCRIPTION
@alilc/lowcode-utils/es/aeeset.js中 export {AssetItem, AssetType, AssetLevels, Asset, AssetList, AssetBundle, AssetLevel, AssetsJson} from '@alilc/lowcode-types' 向外导出不存在的变量（@alilc/lowcode-types下没有这样的变量），vite使用的esbuild，esbuild的transform环节，会报错，具体文件地址和报错信息如下图。webpack可能会对这种有处理，不会报错。