### PR TITLE
refactor: compatible with CSP, avoid using "document.write"

### DIFF
--- a/packages/designer/src/builtin-simulator/host-view.tsx
+++ b/packages/designer/src/builtin-simulator/host-view.tsx
@@ -113,7 +113,14 @@ class Content extends Component<{ host: BuiltinSimulatorHost }> {
           name="SimulatorRenderer"
           className="lc-simulator-content-frame"
           style={frameStyle}
-          ref={(frame) => sim.mountContentFrame(frame)}
+          ref={(frame) => {
+            if (frame) {
+              frame.onload = () => {
+                return sim.mountContentFrame(frame);
+              };
+              frame.srcdoc = '<!DOCTYPE html>';
+            }
+          }}
         />
       </div>
     );

--- a/packages/designer/tests/utils/bom.ts
+++ b/packages/designer/tests/utils/bom.ts
@@ -14,6 +14,8 @@ interface MockDocument extends Document {
 
 
 const eventsMap : Map<string, Set<Function>> = new Map<string, Set<Function>>();
+const mockSetAttribute = jest.fn();
+const mockEval = jest.fn();
 const mockRemoveAttribute = jest.fn();
 const mockAddEventListener = jest.fn((eventName: string, cb) => {
   if (!eventsMap.has(eventName)) {
@@ -39,14 +41,25 @@ const mockTriggerEventListener = jest.fn((eventName: string, data: any, context:
   }
 });
 
+const mockAppendChild = jest.fn((element: HTMLElement) => {
+  if (element && typeof element.onload === 'function') {
+    setTimeout(() => {
+      // @ts-ignore
+      element.onload();
+    }, 0);
+  }
+  return element;
+});
+
 const mockCreateElement = jest.fn((tagName) => {
   return {
     style: {},
-    appendChild() {},
+    appendChild: mockAppendChild,
     addEventListener: mockAddEventListener,
     removeEventListener: mockRemoveEventListener,
     triggerEventListener: mockTriggerEventListener,
     removeAttribute: mockRemoveAttribute,
+    setAttribute: mockSetAttribute,
   };
 });
 
@@ -60,7 +73,8 @@ export function getMockDocument(): MockDocument {
     triggerEventListener: mockTriggerEventListener,
     createElement: mockCreateElement,
     removeChild() {},
-    body: { appendChild() {}, removeChild() {} },
+    head: { appendChild: mockAppendChild, removeChild() {} },
+    body: { appendChild: mockAppendChild, removeChild() {} },
   };
 }
 
@@ -71,6 +85,7 @@ export function getMockWindow(doc?: MockDocument) {
     removeEventListener: mockRemoveEventListener,
     triggerEventListener: mockTriggerEventListener,
     document: doc || getMockDocument(),
+    eval: mockEval,
   };
 }
 


### PR DESCRIPTION
说明
- 解决问题 #1053 

- 原来的 `createSimulator` 逻辑是在 window load 事件触发后进行回调。在改写 document.write 能力后，window load 不会再触发。对此抽象 `loadJsCss` 方法，在所有资源文件加载完成后，再触发回调，若资源有 404 也会触发回调，与原来的逻辑保持一致。

- 对于资源 type 信息，使用 data-level 描述在组件标签上，代替原来的 &lt;meta level="*" /&gt;
![image](https://user-images.githubusercontent.com/5383506/190624626-572a6ec7-0fef-41d5-b5de-9011f32bcdb5.png)
