### PR TITLE
fix: fix empty string lost when  generate variable

### DIFF
--- a/modules/code-generator/src/utils/compositeType.ts
+++ b/modules/code-generator/src/utils/compositeType.ts
@@ -134,13 +134,14 @@ function generateUnknownType(
     };
 
     if (options.handlers?.expression) {
-      return executeFunctionStack(
+      const expression = executeFunctionStack(
         transValue,
         scope,
         options.handlers.expression,
         generateExpression,
         options,
       );
+      return expression || 'undefined';
     }
     return generateExpression(transValue, scope);
   }

--- a/modules/code-generator/tests/utils/compositeType.test.ts
+++ b/modules/code-generator/tests/utils/compositeType.test.ts
@@ -1,4 +1,5 @@
 import { generateCompositeType } from '../../src/utils/compositeType';
+import { parseExpressionConvertThis2Context } from '../../src/utils/expressionParser';
 import { Scope } from '../../src/utils/Scope';
 
 test('single line string', () => {
@@ -16,3 +17,125 @@ test('string with single quote', () => {
 test('string with double quote', () => {
   expect(generateCompositeType('a"bc', Scope.createRootScope())).toEqual('"a\\"bc"');
 });
+
+const marcoFactory = () => {
+  const cases: any[] = [];
+
+  const marco = (value: any, cb: (expression: string) => void) => {
+    cases.push([value, cb]);
+  };
+
+  const start = () => {
+    test.each(cases)('parse expression %s', (item, cb) => {
+      const testObj = {
+        globalConfig: {},
+        online: [
+          {
+            description: '表格（CnTable）的数据源',
+            initialData: {
+              type: 'variable',
+              variable: item,
+              value: '',
+            },
+            somethingelse: 'somethingelse',
+          },
+        ],
+      };
+      const ret = generateCompositeType(testObj, Scope.createRootScope(), {
+        handlers: {
+          function: (jsFunc) => parseExpressionConvertThis2Context(jsFunc.value, '_this'),
+          expression: (jsExpr) => parseExpressionConvertThis2Context(jsExpr.value, '_this'),
+        },
+      });
+      cb(ret);
+    });
+  };
+
+  return { marco, start };
+};
+
+const { marco: testMarco, start: startMarco } = marcoFactory();
+
+/**
+ * dataSource 为低码编辑器里面数据源的输入
+ * variable 为 schema 存储的结果
+ * expect 为出码后期望生产的串
+
+ * |dataSource         | variable                   | expect
+ * |-------------------|----------------------------|--------------
+ * |""                 | "\"\""                     | ""
+ * |"helo world"       | "\"hello world\""          | "hello world"
+ * |true               | "true"                     | true
+ * |false              | "false"                    | false
+ * |{"name": gaokai}   | "{\"name\": \"cone\"}"     | {"name": gaokai}
+ * |                   | ""                         | undefined
+ * |undefined          | "undefined"                | undefined
+ * |null               | "null"                     | null
+ */
+
+testMarco('""', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": \\"\\",
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('"hello world"', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": \\"hello world\\",
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('true', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": true,
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('{"name": "cone"}', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": {
+      \\"name\\": \\"cone\\"
+    },
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": undefined,
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('undefined', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": undefined,
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+testMarco('null', (expression) => {
+  expect(expression).toMatchInlineSnapshot(`
+    "{\\"globalConfig\\": {},
+    \\"online\\": [{\\"description\\": \\"表格（CnTable）的数据源\\",
+    \\"initialData\\": null,
+    \\"somethingelse\\": \\"somethingelse\\"}]}"
+  `);
+});
+
+startMarco();


### PR DESCRIPTION
生成 dataSource 时候，如果 variable 为空字符串，在字符串拼接的时候啥都没了，而作为代码应该拼接为两个引号
test case 有注释说明
![image](https://user-images.githubusercontent.com/28390447/197743205-96dd7bc4-74ce-4cba-b797-5d8887d86d04.png)
暂时 test case 都跑过了，但需要维护者全面评估下这个改动，或者看有没其他合理方案来修复
![image](https://user-images.githubusercontent.com/28390447/197743425-58830d48-90b7-4b0a-be81-91c31266e46b.png)
