### PR TITLE
refactor: provide a typing for PluginConfigCreator

### DIFF
--- a/packages/designer/src/plugin/plugin-types.ts
+++ b/packages/designer/src/plugin/plugin-types.ts
@@ -1,11 +1,6 @@
 import { CompositeObject, ComponentAction } from '@alilc/lowcode-types';
 import Logger from 'zen-logger';
-import {
-  Hotkey,
-  Skeleton,
-  Project,
-  Event, Material,
-} from '@alilc/lowcode-shell';
+import { Hotkey, Skeleton, Project, Event, Material } from '@alilc/lowcode-shell';
 import { EngineConfig } from '@alilc/lowcode-editor-core';
 import { MetadataTransducer } from '@alilc/lowcode-designer';
 import { Setters } from '../types';
@@ -94,7 +89,10 @@ export interface IDesignerCabin {
 
 export interface IPluginPreferenceMananger {
   // eslint-disable-next-line max-len
-  getPreferenceValue: (key: string, defaultValue?: PreferenceValueType) => PreferenceValueType | undefined ;
+  getPreferenceValue: (
+    key: string,
+    defaultValue?: PreferenceValueType,
+  ) => PreferenceValueType | undefined;
 }
 
 export interface ILowCodePluginContext {
@@ -136,11 +134,34 @@ export function isLowCodeRegisterOptions(opts: any): opts is ILowCodeRegisterOpt
 }
 
 export interface ILowCodeRegisterOptions {
+  /** Will enable plugin registered with auto-initialization immediately
+   * other than plugin-manager init all plugins at certain time.
+   * It is helpful when plugin register is later than plugin-manager initialization. */
   autoInit?: boolean;
-  // allow overriding existing plugin with same name when override === true
+  /** allow overriding existing plugin with same name when override === true */
   override?: boolean;
 }
 
 export interface IPluginContextOptions {
   pluginName: string;
 }
+
+export interface IPluginMetaDefinition {
+  /** define dependencies which the plugin depends on */
+  dependencies?: string[];
+  /** specify which engine version is compatible with the plugin */
+  engines?: {
+    /** e.g. '^1.0.0' */
+    lowcodeEngine?: string;
+  };
+}
+
+interface IPluginConfigCreatorFn<T extends Record<string, any> = Record<string, any>> {
+  (ctx: ILowCodePluginContext, pluginOptions?: T): ILowCodePluginConfig;
+}
+
+export type IPluginConfigCreator<T extends Record<string, any> = Record<string, any>> =
+  IPluginConfigCreatorFn<T> & {
+    pluginName: string;
+    meta?: IPluginMetaDefinition;
+  };

--- a/packages/engine/src/modules/designer-types.ts
+++ b/packages/engine/src/modules/designer-types.ts
@@ -12,6 +12,7 @@ export type SettingField = designerCabin.SettingField;
 export type ILowCodePluginConfig = designerCabin.ILowCodePluginConfig;
 export type ILowCodePluginManager = designerCabin.ILowCodePluginManager;
 export type ILowCodePluginContext = designerCabin.ILowCodePluginContext;
+export type IPluginConfigCreator = designerCabin.IPluginConfigCreator;
 export type PluginPreference = designerCabin.PluginPreference;
 export type PropsReducerContext = designerCabin.PropsReducerContext;
 export type DragObjectType = designerCabin.DragObjectType;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1195765/198212841-8d3d5d7e-5fca-4067-98f6-79c8317b06a4.png)
![image](https://user-images.githubusercontent.com/1195765/198212630-ef3f07d5-a7b8-4ddb-ba15-7d73c66e83ff.png)
![image](https://user-images.githubusercontent.com/1195765/198213003-268c0173-4c1d-4a08-85e0-6116c68ea1cb.png)

Now you can get ctx / options / pluginName / meta with type assistant~