### PR TITLE
fix: fix historySymbol is undefined causing errores when calling the history method

### DIFF
--- a/packages/shell/src/document-model.ts
+++ b/packages/shell/src/document-model.ts
@@ -56,7 +56,7 @@ export default class DocumentModel {
     this[editorSymbol] = document.designer.editor as Editor;
     this.selection = new Selection(document);
     this.detecting = new Detecting(document);
-    this.history = new History(document.getHistory());
+    this.history = new History(document);
     this.canvas = new Canvas(document.designer);
 
     this._focusNode = Node.create(this[documentSymbol].focusNode);

--- a/packages/shell/src/history.ts
+++ b/packages/shell/src/history.ts
@@ -1,11 +1,15 @@
 import { History as InnerHistory, DocumentModel as InnerDocumentModel } from '@alilc/lowcode-designer';
-import { historySymbol } from './symbols';
+import { historySymbol, documentSymbol } from './symbols';
 
 export default class History {
-  private readonly [historySymbol]: InnerHistory;
+  private readonly [documentSymbol]: InnerDocumentModel;
 
-  constructor(history: InnerHistory) {
-    this[historySymbol] = history;
+  private get [historySymbol]() {
+    return this[documentSymbol].getHistory();
+  }
+
+  constructor(document: InnerDocumentModel) {
+    this[documentSymbol] = document;
   }
 
   /**


### PR DESCRIPTION
fix: fixed history[historySymbol] appearing undefined under partial execution order

修复在部分执行顺序下，history[historySymbol] 出现 undefined

如图：
![image](https://user-images.githubusercontent.com/11935995/198552513-949610f6-4681-49a5-8278-90c901eeb60a.png)

原因：
部分情况下 InnerDocumentModel history 方法还未初始化成功，这时候 document.getHistory() 的值为 undefined。

这时候 shell/history 下的方法调用都会出现错误