### PR TITLE
chore: set packages that cannot be used publicly private configuration true

### DIFF
--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@alilc/lowcode-designer",
   "version": "1.0.15",
+  "private": true,
   "description": "Designer for Ali LowCode Engine",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@alilc/lowcode-editor-core",
   "version": "1.0.15",
+  "private": true,
   "description": "Core Api for Ali lowCode engine",
   "license": "MIT",
   "main": "lib/index.js",

--- a/packages/editor-skeleton/package.json
+++ b/packages/editor-skeleton/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@alilc/lowcode-editor-skeleton",
   "version": "1.0.15",
+  "private": true,
   "description": "alibaba lowcode editor skeleton",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@alilc/lowcode-plugin-designer",
   "version": "1.0.15",
+  "private": true,
   "description": "alibaba lowcode editor designer plugin",
   "files": [
     "es",

--- a/packages/plugin-outline-pane/package.json
+++ b/packages/plugin-outline-pane/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@alilc/lowcode-plugin-outline-pane",
   "version": "1.0.15",
+  "private": true,
   "description": "Outline pane for Ali lowCode engine",
   "files": [
     "es",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@alilc/lowcode-shell",
+  "private": true,
   "version": "1.0.15",
   "description": "Shell Layer for AliLowCodeEngine",
   "main": "lib/index.js",


### PR DESCRIPTION
chore: set packages that cannot be used publicly private configuration true

设置不提供对外使用方法的 npm package.json 中 private 配置为 true，之后不再发布下列包的 npm 包版本：
- @alilc/lowcode-designer
- @alilc/lowcode-editor-core
- @alilc/lowcode-editor-skeleton
- @alilc/lowcode-plugin-designer
- @alilc/lowcode-plugin-outline-pane
- @alilc/lowcode-shell