### PR TITLE
fix: fix rgl container crash problem, remove invalid rgl.drop event

### DIFF
--- a/packages/designer/src/designer/dragon.ts
+++ b/packages/designer/src/designer/dragon.ts
@@ -408,7 +408,7 @@ export class Dragon {
       if (e) {
         const { isRGL, rglNode } = getRGL(e);
         /* istanbul ignore next */
-        if (isRGL && this._canDrop) {
+        if (isRGL && this._canDrop && this._dragging) {
           const tarNode = dragObject.nodes[0];
           if (rglNode.id !== tarNode.id) {
             // 避免死循环


### PR DESCRIPTION
修复 RGL 容器的卡顿问题。

复现场景，当拖拽一个组件到  RGL 容器中之后，再触发点击，即 mouseup 事件会触发 rgl.drop，此时实际上没有进行拖拽动作。此时的父子组件的关系是有问题的，触发的 rgl.drop 导致 RGL 场景奔溃。

新增 _dragging （dragstart 时才会设置为 true）判断，再进行 rgl.drop 事件的触发。