### PR TITLE
fix: fix the problem of crash caused by infinite loop in antd scene

### DIFF
--- a/packages/editor-skeleton/src/components/settings/settings-pane.tsx
+++ b/packages/editor-skeleton/src/components/settings/settings-pane.tsx
@@ -67,19 +67,31 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
     this.stageName = stageName;
   }
 
-  render() {
-    const { field } = this.props;
-    const { extraProps, componentMeta } = field;
-    const { condition, defaultValue } = extraProps;
-    let visible;
+  get field() {
+    return this.props.field;
+  }
+
+  get visible() {
+    const { extraProps } = this.field;
+    const { condition } = extraProps;
     try {
-      visible = typeof condition === 'function' ? condition(field.internalToShellPropEntry()) !== false : true;
+      return typeof condition === 'function' ? condition(this.field.internalToShellPropEntry()) !== false : true;
     } catch (error) {
       console.error('exception when condition (hidden) is excuted', error);
     }
 
-    const { setter } = field;
+    return true;
+  }
 
+  get setterInfo(): {
+    setterProps: any;
+    initialValue: any;
+    setterType: any;
+  } {
+    const { extraProps, componentMeta } = this.field;
+    const { defaultValue } = extraProps;
+
+    const { setter } = this.field;
     let setterProps: any = {};
     let setterType: any;
     let initialValue: any = null;
@@ -94,7 +106,7 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
       if (setter.props) {
         setterProps = setter.props;
         if (typeof setterProps === 'function') {
-          setterProps = setterProps(field.internalToShellPropEntry());
+          setterProps = setterProps(this.field.internalToShellPropEntry());
         }
       }
       if (setter.initialValue != null) {
@@ -104,36 +116,22 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
       setterType = setter;
     }
 
-    let value = null;
     if (defaultValue != null && !('defaultValue' in setterProps)) {
       setterProps.defaultValue = defaultValue;
       if (initialValue == null) {
         initialValue = defaultValue;
       }
     }
-    if (field.valueState === -1) {
+
+    if (this.field.valueState === -1) {
       setterProps.multiValue = true;
       if (!('placeholder' in setterProps)) {
         setterProps.placeholder = intl('Multiple Value');
       }
-    } else {
-      value = field.getValue();
-    }
-
-    // 当前 field 没有 value 值时，将 initialValue 写入 field
-    // 之所以用 initialValue，而不是 defaultValue 是为了保持跟 props.onInitial 的逻辑一致
-    if (!this.state?.fromOnChange && value === undefined && isInitialValueNotEmpty(initialValue)) {
-      const _initialValue = typeof initialValue === 'function' ? initialValue(field.internalToShellPropEntry()) : initialValue;
-      field.setValue(_initialValue);
-      value = _initialValue;
-    }
-
-    if (!visible) {
-      return null;
     }
 
     // 根据是否支持变量配置做相应的更改
-    const supportVariable = field.extraProps?.supportVariable;
+    const supportVariable = this.field.extraProps?.supportVariable;
     // supportVariableGlobally 只对标准组件生效，vc 需要单独配置
     const supportVariableGlobally = engineConfig.get('supportVariableGlobally', false) && isStandardComponent(componentMeta);
     if (supportVariable || supportVariableGlobally) {
@@ -152,6 +150,53 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
         };
       }
     }
+
+    return {
+      setterProps,
+      initialValue,
+      setterType,
+    };
+  }
+
+  get value() {
+    return this.field.valueState === -1 ? null : this.field.getValue();
+  }
+
+  initDefaultValue() {
+    const { initialValue } = this.setterInfo;
+    if (this.state?.fromOnChange ||
+      !isInitialValueNotEmpty(initialValue) ||
+      this.value !== undefined
+    ) {
+      return;
+    }
+    // 当前 field 没有 value 值时，将 initialValue 写入 field
+    // 之所以用 initialValue，而不是 defaultValue 是为了保持跟 props.onInitial 的逻辑一致
+    const _initialValue = typeof initialValue === 'function' ? initialValue(this.field.internalToShellPropEntry()) : initialValue;
+    this.field.setValue(_initialValue);
+  }
+
+  componentDidMount() {
+    this.initDefaultValue();
+  }
+
+  render() {
+    const field = this.field;
+    const { extraProps } = field;
+    const visible = this.visible;
+
+    if (!visible) {
+      return null;
+    }
+
+    const {
+      setterProps = {},
+      setterType,
+      initialValue = null,
+
+    } = this.setterInfo;
+
+    const value = this.value;
 
     let _onChange = extraProps?.onChange;
     let stageName = this.stageName;

--- a/packages/types/src/field-config.ts
+++ b/packages/types/src/field-config.ts
@@ -61,6 +61,11 @@ export interface FieldExtraProps {
    * @todo 待补充文档
    */
   liveTextEditing?: Omit<LiveTextEditingConfig, 'propTarget'>;
+
+  /**
+   * onChange 事件
+   */
+  onChange?: (value: any, field: any) => void;
 }
 
 /**


### PR DESCRIPTION
fixed: https://github.com/alibaba/lowcode-engine/issues/1255

问题相关 PR：https://github.com/alibaba/lowcode-engine/commit/fcfce3cbeb5a53600c40aea07ffef19c9c9591c4

问题原因：
antd 的物料配置如下：
![image](https://user-images.githubusercontent.com/11935995/203986110-a5bcd6ed-0b89-4515-befa-776318e2eb2f.png)

其中 Antd 的 rowSelection 值类型默认为 bool，但是当其打开时，其值是一个 object。
在 1.0.15 之前的版本，也就是这个 PR 之前，原来 rowSelection.type 不会进行初始化，在**本次变更**之后，rowSelection.type 进行了初始化配置。 rowSelection.type 会执行 value = field.getValue(); 这一步会重新将 rowSelection 置为 type:map 类型的空对象。在下一次获取 rowSelection 的值时，由于 items 都没有初始化，返回的还是 undefined，导致重复循环该步骤。

本次 PR 修复问题并将 SettingFieldView 相关的代码进行重构：
1.将 setter 相关的信息初始化和默认值初始化放到 constructor
2.只有包含 initialValue 的才会计算 value。
