### PR TITLE
Fix/valid component name

### DIFF
--- a/modules/code-generator/package.json
+++ b/modules/code-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alilc/lowcode-code-generator",
-  "version": "1.0.7-beta.2",
+  "version": "1.0.7-beta.3",
   "description": "出码引擎 for LowCode Engine",
   "license": "MIT",
   "main": "lib/index.js",

--- a/modules/code-generator/src/plugins/common/esmodule.ts
+++ b/modules/code-generator/src/plugins/common/esmodule.ts
@@ -16,7 +16,7 @@ import {
   IWithDependency,
 } from '../../types';
 
-import { isValidIdentifier } from '../../utils/validate';
+import { isValidIdentifier, isValidComponentName } from '../../utils/validate';
 
 // TODO: main 这个信息到底怎么用，是不是外部包不需要使用？
 const DEP_MAIN_BLOCKLIST = ['lib', 'lib/index', 'es', 'es/index', 'main'];
@@ -261,7 +261,7 @@ function buildPackageImport(
     if (!isValidIdentifier(name)) {
       throw new CodeGeneratorError(`Invalid Identifier [${name}]`);
     }
-    if (info.nodeIdentifier && !isValidIdentifier(info.nodeIdentifier)) {
+    if (info.nodeIdentifier && !isValidComponentName(info.nodeIdentifier)) {
       throw new CodeGeneratorError(`Invalid Identifier [${info.nodeIdentifier}]`);
     }
   });

--- a/modules/code-generator/src/utils/validate.ts
+++ b/modules/code-generator/src/utils/validate.ts
@@ -2,6 +2,10 @@ export const isValidIdentifier = (name: string) => {
   return /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*$/.test(name);
 };
 
+export const isValidComponentName = (name: string) => {
+  return /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF.]*$/.test(name);
+};
+
 export const ensureValidClassName = (name: string) => {
   if (!isValidIdentifier(name)) {
     return `$${name.replace(/[^_$a-zA-Z0-9]/g, '')}`;


### PR DESCRIPTION
fixes #1263 

对于 componentName，因为可以包含 Form.Item / Tab.Item / Button.Group 等嵌套场景，所以不应该是否「JS 标识符」去限定，修改为「JS 标识符 + .」的组合~