### PR TITLE
feat: remove circular dependency between designer and shell

### DIFF
--- a/docs/docs/api/plugins.md
+++ b/docs/docs/api/plugins.md
@@ -223,15 +223,16 @@ plugins.delete('builtinPluginRegistry');
 **类型定义**
 ```typescript
 export interface ILowCodePluginContext {
-  skeleton: Skeleton;                // 参考面板 API
-  hotkey: Hotkey;                    // 参考快捷键 API
-  logger: Logger;                    // 参考日志 API
-  plugins: ILowCodePluginManager;    // 参考插件 API
-  setters: Setters;                  // 参考设置器 API
-  config: EngineConfig;              // 参考配置 API
-  material: Material;                // 参考物料 API
-  event: Event;                      // 参考事件 API
-  project: Project;                  // 参考模型 API
+  skeleton: Skeleton;                       // 参考面板 API
+  hotkey: Hotkey;                           // 参考快捷键 API
+  setters: Setters;                         // 参考设置器 API
+  config: EngineConfig;                     // 参考配置 API
+  material: Material;                       // 参考物料 API
+  event: Event;                             // 参考事件 API
+  project: Project;                         // 参考模型 API
+  common: Common;                           // 参考模型 API
+  logger: Logger;                           // 参考日志 API
+  plugins: ILowCodePluginManager;           // 即本文档描述内容
   preference: IPluginPreferenceMananger;
 }
 ```

--- a/docs/docs/participate/flow.md
+++ b/docs/docs/participate/flow.md
@@ -91,6 +91,7 @@ sidebar_position: 2
 2. 拉 release 分支，此处以 1.0.1 版本做示例
    ```bash
    git checkout -b release/1.0.1-beta
+   git push --set-upstream origin release/1.0.1-beta
    ```
 3. build
    ```bash

--- a/packages/designer/jest.config.js
+++ b/packages/designer/jest.config.js
@@ -10,6 +10,7 @@ const jestConfig = {
   //   // '^.+\\.(js|jsx)$': 'babel-jest',
   // },
   // testMatch: ['**/node-children.test.ts'],
+  // testMatch: ['**/plugin-manager.test.ts'],
   // testMatch: ['**/history/history.test.ts'],
   // testMatch: ['**/host-view.test.tsx'],
   // testMatch: ['(/tests?/.*(test))\\.[jt]s$'],

--- a/packages/designer/src/plugin/plugin-manager.ts
+++ b/packages/designer/src/plugin/plugin-manager.ts
@@ -1,4 +1,4 @@
-import { Editor, engineConfig } from '@alilc/lowcode-editor-core';
+import { engineConfig } from '@alilc/lowcode-editor-core';
 import { getLogger } from '@alilc/lowcode-utils';
 import {
   ILowCodePlugin,
@@ -12,9 +12,11 @@ import {
   PluginPreference,
   ILowCodePluginPreferenceDeclaration,
   isLowCodeRegisterOptions,
+  ILowCodePluginContextApiAssembler,
 } from './plugin-types';
 import { filterValidOptions } from './plugin-utils';
 import { LowCodePlugin } from './plugin';
+// eslint-disable-next-line import/no-named-as-default
 import LowCodePluginContext from './plugin-context';
 import { invariant } from '../utils';
 import sequencify from './sequencify';
@@ -28,14 +30,15 @@ export class LowCodePluginManager implements ILowCodePluginManager {
   private pluginsMap: Map<string, ILowCodePlugin> = new Map();
 
   private pluginPreference?: PluginPreference = new Map();
-  private editor: Editor;
 
-  constructor(editor: Editor) {
-    this.editor = editor;
+  contextApiAssembler: ILowCodePluginContextApiAssembler;
+
+  constructor(contextApiAssembler: ILowCodePluginContextApiAssembler) {
+    this.contextApiAssembler = contextApiAssembler;
   }
 
   private _getLowCodePluginContext(options: IPluginContextOptions) {
-    return new LowCodePluginContext(this, options);
+    return new LowCodePluginContext(this, options, this.contextApiAssembler);
   }
 
   isEngineVersionMatched(versionExp: string): boolean {

--- a/packages/designer/src/plugin/plugin-types.ts
+++ b/packages/designer/src/plugin/plugin-types.ts
@@ -1,6 +1,6 @@
 import { CompositeObject, ComponentAction } from '@alilc/lowcode-types';
 import Logger from 'zen-logger';
-import { Hotkey, Skeleton, Project, Event, Material } from '@alilc/lowcode-shell';
+import { Hotkey, Skeleton, Project, Event, Material, Common } from '@alilc/lowcode-shell';
 import { EngineConfig } from '@alilc/lowcode-editor-core';
 import { MetadataTransducer } from '@alilc/lowcode-designer';
 import { Setters } from '../types';
@@ -96,17 +96,32 @@ export interface IPluginPreferenceMananger {
 }
 
 export interface ILowCodePluginContext {
-  skeleton: Skeleton;
-  hotkey: Hotkey;
+  get skeleton(): Skeleton;
+  get hotkey(): Hotkey;
+  get setters(): Setters;
+  get config(): EngineConfig;
+  get material(): Material;
+  get event(): Event;
+  get project(): Project;
+  get common(): Common;
   logger: Logger;
   plugins: ILowCodePluginManager;
-  setters: Setters;
-  config: EngineConfig;
-  material: Material;
-  event: Event;
-  project: Project;
   preference: IPluginPreferenceMananger;
 }
+export interface ILowCodePluginContextPrivate {
+  set hotkey(hotkey: Hotkey);
+  set project(project: Project);
+  set skeleton(skeleton: Skeleton);
+  set setters(setters: Setters);
+  set material(material: Material);
+  set event(event: Event);
+  set config(config: EngineConfig);
+  set common(common: Common);
+}
+export interface ILowCodePluginContextApiAssembler {
+  assembleApis: (context: ILowCodePluginContextPrivate) => void;
+}
+
 
 interface ILowCodePluginManagerPluginAccessor {
   [pluginName: string]: ILowCodePlugin | any;

--- a/packages/designer/tests/plugin/plugin-manager.test.ts
+++ b/packages/designer/tests/plugin/plugin-manager.test.ts
@@ -1,14 +1,19 @@
 import '../fixtures/window';
 import { Editor, engineConfig } from '@alilc/lowcode-editor-core';
 import { LowCodePluginManager } from '../../src/plugin/plugin-manager';
-import { ILowCodePluginContext, ILowCodePluginManager } from '../../src/plugin/plugin-types';
+import { ILowCodePluginContext, ILowCodePluginManager, ILowCodePluginContextApiAssembler } from '../../src/plugin/plugin-types';
 
 const editor = new Editor();
+const contextApiAssembler = {
+  assembleApis(){
+    // mock set apis
+  }
+};
 
 describe('plugin 测试', () => {
   let pluginManager: ILowCodePluginManager;
   beforeEach(() => {
-    pluginManager = new LowCodePluginManager(editor).toProxy();
+    pluginManager = new LowCodePluginManager(contextApiAssembler).toProxy();
   });
   afterEach(() => {
     pluginManager.dispose();

--- a/packages/engine/src/engine-core.ts
+++ b/packages/engine/src/engine-core.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { createElement } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { globalContext, Editor, engineConfig, EngineOptions } from '@alilc/lowcode-editor-core';
@@ -5,6 +6,8 @@ import {
   Designer,
   LowCodePluginManager,
   ILowCodePluginContext,
+  ILowCodePluginContextPrivate,
+  ILowCodePluginContextApiAssembler,
   PluginPreference,
 } from '@alilc/lowcode-designer';
 import {
@@ -46,10 +49,6 @@ editor.set('skeleton' as any, innerSkeleton);
 
 const designer = new Designer({ editor });
 editor.set('designer' as any, designer);
-
-const plugins = new LowCodePluginManager(editor).toProxy();
-editor.set('plugins' as any, plugins);
-
 const { project: innerProject } = designer;
 
 const hotkey = new Hotkey();
@@ -61,6 +60,21 @@ const config = engineConfig;
 const event = new Event(editor, { prefix: 'common' });
 const logger = getLogger({ level: 'warn', bizName: 'common' });
 const common = new Common(editor, innerSkeleton);
+
+const pluginContextApiAssembler: ILowCodePluginContextApiAssembler = {
+  assembleApis: (context: ILowCodePluginContextPrivate) => {
+    context.hotkey = hotkey;
+    context.project = project;
+    context.skeleton = skeleton;
+    context.setters = setters;
+    context.material = material;
+    context.event = event;
+    context.config = config;
+    context.common = common;
+  },
+};
+const plugins = new LowCodePluginManager(pluginContextApiAssembler).toProxy();
+editor.set('plugins' as any, plugins);
 
 export {
   skeleton,


### PR DESCRIPTION
将plugin context的api灌装逻辑移到了engine-core, 并补充了common api，为下一步彻底接触 designer 和 shell 循环依赖做准备