### PR TITLE
fix: add null protection for LowcodeTypes.shape

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,7 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @leoyuan @JackLian
+* @liujuping @JackLian
 
 /modules/material-parser @akirakai
-/modules/code-generator @Clarence-pan
-
-/packages/renderer-core/ @liujuping
-/packages/react-renderer/ @liujuping
-/packages/react-simulator-renderer/ @liujuping
-/packages/rax-renderer/ @liujuping
-/packages/rax-simulator-renderer/ @liujuping
+/modules/code-generator @leoyuan

--- a/packages/designer/src/builtin-simulator/utils/parse-metadata.ts
+++ b/packages/designer/src/builtin-simulator/utils/parse-metadata.ts
@@ -113,7 +113,7 @@ LowcodeTypes.exact = (typesMap: any) => {
 };
 
 // An object taking on a particular shape
-LowcodeTypes.shape = (typesMap: any) => {
+LowcodeTypes.shape = (typesMap: any = {}) => {
   const configs = Object.keys(typesMap).map(key => {
     return {
       name: key,

--- a/packages/designer/tests/builtin-simulator/utils/parse-metadata.test.ts
+++ b/packages/designer/tests/builtin-simulator/utils/parse-metadata.test.ts
@@ -6,4 +6,8 @@ describe('parseMetadata', () => {
     const md1 = parseMetadata('Div');
     const md2 = parseMetadata({ componentName: 'Div' });
   });
+  it('LowcodeTypes.shape', async () => {
+    const result = (window as any).PropTypes.shape()
+    expect(result).toBeDefined();
+  });
 });


### PR DESCRIPTION
为LowcodeTypes.shape函数增加默认值，防止空值时的运行时错误。
这个问题出现在低代码引擎集成到@umijs/max项目并且版本号大于等4.0.30时，此版本引入react-helmet-async，这个包中有如下图1用法，最终导致在运行期间报错。报错如下图2。
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/1539586/204458980-e12d31a8-1ce7-4741-8df0-a8e74e15e2cd.png">
报错如下
<img width="939" alt="image" src="https://user-images.githubusercontent.com/1539586/204459136-a2d20af4-a5a6-4f30-bd7f-dffc3bbf53b1.png">

