### PR TITLE
fix: compatible with SlotSchema which doesn't have title / name / params

### DIFF
--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -315,9 +315,17 @@ export class Prop implements IPropParent {
   setAsSlot(data: JSSlot) {
     this._type = 'slot';
     let slotSchema: SlotSchema;
-    // 当 data.value 的结构为 { componentName: 'Slot' } 时，直接当成 slotSchema 使用
+    // 当 data.value 的结构为 { componentName: 'Slot' } 时，复用部分 slotSchema 数据
     if ((isPlainObject(data.value) && data.value?.componentName === 'Slot')) {
-      slotSchema = data.value as SlotSchema;
+      const value = data.value as SlotSchema;
+      slotSchema = {
+        componentName: 'Slot',
+        title: value.title || value.props?.slotTitle,
+        id: data.id,
+        name: value.name || value.props?.slotName,
+        params: value.params || value.props?.slotParams,
+        children: data.value,
+      } as SlotSchema;
     } else {
       slotSchema = {
         componentName: 'Slot',

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -162,7 +162,14 @@ export type RootSchema = PageSchema | ComponentSchema | BlockSchema;
 export interface SlotSchema extends NodeSchema {
   componentName: 'Slot';
   name?: string;
+  title?: string;
   params?: string[];
+  props?: {
+    slotTitle?: string;
+    slotName?: string;
+    slotParams?: string[];
+  };
+  children?: NodeSchema[];
 }
 
 /**


### PR DESCRIPTION
部分场景存在

```js
var slotSchema = {
  componentName: 'Slot',
  ...
  props: {
    slotName / slotTitle / slotParams 
  }
}
```

的数据结构，而引擎对于这类结构会丢失 props 下的 3 个属性，这个 PR 将数据补全~