### PR TITLE
feat: add function return for event setter

### DIFF
--- a/packages/editor-skeleton/src/transducers/addon-combine.ts
+++ b/packages/editor-skeleton/src/transducers/addon-combine.ts
@@ -224,7 +224,7 @@ export default function (metadata: TransformedComponentMetadata): TransformedCom
               field.parent.setPropValue(item.name, {
                 type: 'JSFunction',
                 // 需要传下入参
-                value: `function(){this.${item.relatedEventName}.apply(this,Array.prototype.slice.call(arguments).concat([${item.paramStr ? item.paramStr : ''}])) }`,
+                value: `function(){return this.${item.relatedEventName}.apply(this,Array.prototype.slice.call(arguments).concat([${item.paramStr ? item.paramStr : ''}])) }`,
               });
               return item;
             });


### PR DESCRIPTION
为事件设置器绑定的函数模板增加return，解决物料内部需要根据使用侧绑定的函数来控制内部状态的需求，例如弹窗中确认按钮根据onOk函数是否结束并返回bool值控制按钮的loading以及是否关闭弹窗（类似ModalForm）