### PR TITLE
fix: fix isJSFunction lacks the judgment of the old version of the protocol

### DIFF
--- a/packages/utils/src/check-types/is-isfunction.ts
+++ b/packages/utils/src/check-types/is-isfunction.ts
@@ -1,4 +1,10 @@
+/**
+ *  内部版本 的 { type: 'JSExpression', source: '', value: '', extType: 'function' } 能力上等同于 JSFunction
+ */
+export function isInnerJsFunction(data: any) {
+  return data && data.type === 'JSExpression' && data.extType === 'function';
+}
 
-export function isJSFunction(x: any): boolean {
-  return typeof x === 'object' && x && x.type === 'JSFunction';
+export function isJSFunction(data: any): boolean {
+  return typeof data === 'object' && data && data.type === 'JSFunction' || isInnerJsFunction(data);
 }


### PR DESCRIPTION
fix: fix isJSFunction lacks the judgment of the old version of the protocol

关联 PR：https://github.com/alibaba/lowcode-engine/pull/1270/files