### PR TITLE
fix: getting slot children incorrectly

### DIFF
--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -404,7 +404,7 @@ export class Prop implements IProp, IPropParent {
         id: data.id,
         name: value.name || value.props?.slotName,
         params: value.params || value.props?.slotParams,
-        children: data.value,
+        children: value.children,
       } as IPublicTypeSlotSchema;
     } else {
       slotSchema = {


### PR DESCRIPTION
当判断 data.value 是一个 { componentName: 'Slot' } 时，应该将 data.value.children 传给下方的 children~

当前传递的是整个 data.value，将导致 Slot 多层嵌套