### PR TITLE
fix:修复config onGot 第一次获取到值之后，之后不会继续订阅的问题。

### DIFF
--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -291,14 +291,13 @@ export class EngineConfig implements IPublicModelEngineConfig, IEngineConfigPriv
     const val = this.config?.[key];
     if (val !== undefined) {
       fn(val);
-      return () => {};
-    } else {
-      this.setWait(key, fn);
-      return () => {
-        this.delWait(key, fn);
-      };
     }
+    this.setWait(key, fn);
+    return () => {
+      this.delWait(key, fn);
+    };
   }
+
 
   notifyGot(key: string): void {
     let waits = this.waits.get(key);


### PR DESCRIPTION
文档描叙：config 的 onGot 获取指定 key 的值，函数回调模式，若多次被赋值，回调会被多次调用
实际：第一次就获取到值，回调直接执行，且不再订阅该key的更新，后续无法触发回调