### PR TITLE
fix:config onGot api 与文档描叙不一致

### DIFF
--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -291,13 +291,11 @@ export class EngineConfig implements IPublicModelEngineConfig, IEngineConfigPriv
     const val = this.config?.[key];
     if (val !== undefined) {
       fn(val);
-      return () => {};
-    } else {
-      this.setWait(key, fn);
-      return () => {
-        this.delWait(key, fn);
-      };
     }
+    this.setWait(key, fn);
+    return () => {
+      this.delWait(key, fn);
+    };
   }
 
   notifyGot(key: string): void {


### PR DESCRIPTION
文档描叙： onGot 获取指定 key 的值，函数回调模式，若多次被赋值，回调会被多次调用
实际：第一次有值就不会再触发回调