### PR TITLE
fix: VC组件canResizing发生变化时无法拖拽

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     'no-await-in-loop': 0,
     'no-plusplus': 0,
     '@typescript-eslint/no-parameter-properties': 0,
-    '@typescript-eslint/no-unused-vars': 1,
+    'no-restricted-exports': ['error'],
     'no-multi-assign': 1,
     'no-dupe-class-members': 1,
     'react/no-deprecated': 1,

--- a/.github/workflows/cov packages.yml
+++ b/.github/workflows/cov packages.yml
@@ -72,3 +72,25 @@ jobs:
           test-script: npm test -- --jest-ci --jest-json --jest-coverage --jest-testLocationInResults --jest-outputFile=report.json
           package-manager: yarn
           annotations: none
+
+cov-utils:
+    runs-on: ubuntu-latest
+    # skip fork's PR, otherwise it fails while making a comment
+    if: ${{ github.event.pull_request.head.repo.full_name == 'alibaba/lowcode-engine' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: install
+        run: npm i && npm run setup:skip-build
+
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          working-directory: packages/utils
+          test-script: npm test
+          package-manager: yarn
+          annotations: none

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -24,5 +24,6 @@
 - [Ychangqing](https://github.com/Ychangqing)
 - [yize](https://github.com/yize)
 - [youluna](https://github.com/youluna)
+- [ibreathebsb](https://github.com/ibreathebsb)
 
 如果您贡献过低代码引擎，但是没有看到您的名字，为我们的疏忽感到抱歉。欢迎您通过 PR 补充上自己的名字。

--- a/docs/docs/api/model/config.md
+++ b/docs/docs/api/model/config.md
@@ -1,0 +1,113 @@
+---
+title: Config
+sidebar_position: 16
+---
+> **@types** [IPublicModelEngineConfig](https://github.com/alibaba/lowcode-engine/blob/main/packages/types/src/shell/model/engine-config.ts)<br/>
+> **@since** v1.1.3
+
+## 方法
+### has
+
+判断指定 key 是否有值
+
+```typescript
+/**
+ * 判断指定 key 是否有值
+ * check if config has certain key configed
+ * @param key
+ * @returns
+ */
+has(key: string): boolean;
+```
+
+### get
+
+获取指定 key 的值
+
+```typescript
+/**
+ * 获取指定 key 的值
+ * get value by key
+ * @param key
+ * @param defaultValue
+ * @returns
+ */
+get(key: string, defaultValue?: any): any;
+```
+
+### set
+
+设置指定 key 的值
+
+```typescript
+/**
+ * 设置指定 key 的值
+ * set value for certain key
+ * @param key
+ * @param value
+ */
+set(key: string, value: any): void;
+```
+
+### setConfig
+批量设值，set 的对象版本
+
+```typescript
+/**
+ * 批量设值，set 的对象版本
+ * set multiple config key-values
+ * @param config
+ */
+setConfig(config: { [key: string]: any }): void;
+```
+
+### getPreference
+获取全局 Preference, 用于管理全局浏览器侧用户 Preference，如 Panel 是否钉住
+
+```typescript
+/**
+ * 获取全局 Preference, 用于管理全局浏览器侧用户 Preference，如 Panel 是否钉住
+ * get global user preference manager, which can be use to store
+ * user`s preference in user localstorage, such as a panel is pinned or not.
+ * @returns {IPublicModelPreference}
+ * @since v1.1.0
+ */
+getPreference(): IPublicModelPreference;
+```
+
+相关类型：[IPublicModelPreference](https://github.com/alibaba/lowcode-engine/blob/main/packages/types/src/shell/model/preference.ts)
+
+## 事件
+
+### onGot
+获取指定 key 的值，函数回调模式，若多次被赋值，回调会被多次调用
+
+```typescript
+/**
+ * 获取指定 key 的值，函数回调模式，若多次被赋值，回调会被多次调用
+ * set callback for event of value set for some key
+ * this will be called each time the value is set
+ * @param key
+ * @param fn
+ * @returns
+ */
+onGot(key: string, fn: (data: any) => void): IPublicTypeDisposable;
+```
+
+相关类型：[IPublicTypeDisposable](https://github.com/alibaba/lowcode-engine/blob/main/packages/types/src/shell/type/disposable.ts)
+
+### onceGot
+获取指定 key 的值，若此时还未赋值，则等待，若已有值，则直接返回值
+> 注：此函数返回 Promise 实例，只会执行（fullfill）一次
+
+```typescript
+/**
+ * 获取指定 key 的值，若此时还未赋值，则等待，若已有值，则直接返回值
+ *  注：此函数返回 Promise 实例，只会执行（fullfill）一次
+ * wait until value of certain key is set, will only be
+ * triggered once.
+ * @param key
+ * @returns
+ */
+onceGot(key: string): Promise<any>;
+```

--- a/docs/docs/api/model/node-children.md
+++ b/docs/docs/api/model/node-children.md
@@ -156,6 +156,21 @@ forEach(fn: (node: IPublicModelNode, index: number) => void): void;
 
 相关类型：[IPublicModelNode](https://github.com/alibaba/lowcode-engine/blob/main/packages/types/src/shell/model/node.ts)
 
+### reverse
+
+类似数组的 reverse
+
+```typescript
+/**
+ * 类似数组的 reverse
+ * provide the same function with {Array.prototype.reverse}
+ */
+reverse(): IPublicModelNode[];
+
+```
+
+相关类型：[IPublicModelNode](https://github.com/alibaba/lowcode-engine/blob/main/packages/types/src/shell/model/node.ts)
+
 
 ### map
 

--- a/packages/designer/src/builtin-simulator/bem-tools/border-resizing.tsx
+++ b/packages/designer/src/builtin-simulator/bem-tools/border-resizing.tsx
@@ -254,90 +254,100 @@ export class BoxResizingInstance extends Component<{
 
     return (
       <div>
-        {triggerVisible.includes('N') && (
-          <div
-            ref={(ref) => { this.outlineN = ref; }}
-            className={classNames(baseSideClass, 'n')}
-            style={{
-              height: 20,
-              transform: `translate(${offsetLeft}px, ${offsetTop - 10}px)`,
-              width: offsetWidth,
-            }}
-          />
-        )}
-        {triggerVisible.includes('NE') && (
-          <div
-            ref={(ref) => { this.outlineNE = ref; }}
-            className={classNames(baseCornerClass, 'ne')}
-            style={{
-              transform: `translate(${offsetLeft + offsetWidth - 5}px, ${offsetTop - 3}px)`,
-              cursor: 'nesw-resize',
-            }}
-          />
-        )}
-        {triggerVisible.includes('E') && (
-          <div
-            className={classNames(baseSideClass, 'e')}
-            ref={(ref) => { this.outlineE = ref; }}
-            style={{
-              height: offsetHeight,
-              transform: `translate(${offsetLeft + offsetWidth - 10}px, ${offsetTop}px)`,
-              width: 20,
-            }}
-          />
-        )}
-        {triggerVisible.includes('SE') && (
-          <div
-            ref={(ref) => { this.outlineSE = ref; }}
-            className={classNames(baseCornerClass, 'se')}
-            style={{
-              transform: `translate(${offsetLeft + offsetWidth - 5}px, ${offsetTop + offsetHeight - 5}px)`,
-              cursor: 'nwse-resize',
-            }}
-          />
-        )}
-        {triggerVisible.includes('S') && (
-          <div
-            ref={(ref) => { this.outlineS = ref; }}
-            className={classNames(baseSideClass, 's')}
-            style={{
-              height: 20,
-              transform: `translate(${offsetLeft}px, ${offsetTop + offsetHeight - 10}px)`,
-              width: offsetWidth,
-            }}
-          />
-        )}
-        {triggerVisible.includes('SW') && (
-          <div
-            ref={(ref) => { this.outlineSW = ref; }}
-            className={classNames(baseCornerClass, 'sw')}
-            style={{
-              transform: `translate(${offsetLeft - 3}px, ${offsetTop + offsetHeight - 5}px)`,
-              cursor: 'nesw-resize',
-            }}
-          />
-        )}
-        {triggerVisible.includes('W') && (
-          <div
-            ref={(ref) => { this.outlineW = ref; }}
-            className={classNames(baseSideClass, 'w')}
-            style={{
-              height: offsetHeight,
-              transform: `translate(${offsetLeft - 10}px, ${offsetTop}px)`,
-              width: 20,
-            }}
-          />
-        )}
-        {triggerVisible.includes('NW') && (
-          <div
-            ref={(ref) => { this.outlineNW = ref; }}
-            className={classNames(baseCornerClass, 'nw')}
-            style={{
-              transform: `translate(${offsetLeft - 3}px, ${offsetTop - 3}px)`,
-              cursor: 'nwse-resize',
-            }}
-          />
-        )}
+        <div
+          ref={(ref) => {
+            this.outlineN = ref;
+          }}
+          className={classNames(baseSideClass, 'n')}
+          style={{
+            height: 20,
+            transform: `translate(${offsetLeft}px, ${offsetTop - 10}px)`,
+            width: offsetWidth,
+            display: triggerVisible.includes('N') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineNE = ref;
+          }}
+          className={classNames(baseCornerClass, 'ne')}
+          style={{
+            transform: `translate(${offsetLeft + offsetWidth - 5}px, ${offsetTop - 3}px)`,
+            cursor: 'nesw-resize',
+            display: triggerVisible.includes('NE') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          className={classNames(baseSideClass, 'e')}
+          ref={(ref) => {
+            this.outlineE = ref;
+          }}
+          style={{
+            height: offsetHeight,
+            transform: `translate(${offsetLeft + offsetWidth - 10}px, ${offsetTop}px)`,
+            width: 20,
+            display: triggerVisible.includes('E') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineSE = ref;
+          }}
+          className={classNames(baseCornerClass, 'se')}
+          style={{
+            transform: `translate(${offsetLeft + offsetWidth - 5}px, ${
+              offsetTop + offsetHeight - 5
+            }px)`,
+            cursor: 'nwse-resize',
+            display: triggerVisible.includes('SE') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineS = ref;
+          }}
+          className={classNames(baseSideClass, 's')}
+          style={{
+            height: 20,
+            transform: `translate(${offsetLeft}px, ${offsetTop + offsetHeight - 10}px)`,
+            width: offsetWidth,
+            display: triggerVisible.includes('S') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineSW = ref;
+          }}
+          className={classNames(baseCornerClass, 'sw')}
+          style={{
+            transform: `translate(${offsetLeft - 3}px, ${offsetTop + offsetHeight - 5}px)`,
+            cursor: 'nesw-resize',
+            display: triggerVisible.includes('SW') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineW = ref;
+          }}
+          className={classNames(baseSideClass, 'w')}
+          style={{
+            height: offsetHeight,
+            transform: `translate(${offsetLeft - 10}px, ${offsetTop}px)`,
+            width: 20,
+            display: triggerVisible.includes('W') ? 'flex' : 'none',
+          }}
+        />
+        <div
+          ref={(ref) => {
+            this.outlineNW = ref;
+          }}
+          className={classNames(baseCornerClass, 'nw')}
+          style={{
+            transform: `translate(${offsetLeft - 3}px, ${offsetTop - 3}px)`,
+            cursor: 'nwse-resize',
+            display: triggerVisible.includes('NW') ? 'flex' : 'none',
+          }}
+        />
       </div>
     );
   }

--- a/packages/designer/src/component-meta.ts
+++ b/packages/designer/src/component-meta.ts
@@ -56,7 +56,8 @@ export function buildFilter(rule?: string | string[] | RegExp | IPublicTypeNesti
   return (testNode: Node | IPublicTypeNodeSchema) => list.includes(testNode.componentName);
 }
 
-export interface IComponentMeta extends IPublicModelComponentMeta {
+export interface IComponentMeta extends IPublicModelComponentMeta<INode> {
+  prototype?: any;
 }
 
 export class ComponentMeta implements IComponentMeta {

--- a/packages/designer/src/designer/designer.ts
+++ b/packages/designer/src/designer/designer.ts
@@ -30,7 +30,7 @@ import { ActiveTracker, IActiveTracker } from './active-tracker';
 import { Detecting } from './detecting';
 import { DropLocation } from './location';
 import { OffsetObserver, createOffsetObserver } from './offset-observer';
-import { SettingTopEntry } from './setting';
+import { ISettingTopEntry, SettingTopEntry } from './setting';
 import { BemToolsManager } from '../builtin-simulator/bem-tools/manager';
 import { ComponentActions } from '../component-actions';
 
@@ -61,6 +61,7 @@ export interface DesignerProps {
 }
 
 export interface IDesigner {
+  readonly shellModelFactory: IShellModelFactory;
 
   get dragon(): IPublicModelDragon;
 
@@ -91,6 +92,12 @@ export interface IDesigner {
   getComponentMetasMap(): Map<string, IComponentMeta>;
 
   addPropsReducer(reducer: IPublicTypePropsTransducer, stage: IPublicEnumTransformStage): void;
+
+  postEvent(event: string, ...args: any[]): void;
+
+  transformProps(props: IPublicTypeCompositeObject | IPublicTypePropsList, node: Node, stage: IPublicEnumTransformStage): IPublicTypeCompositeObject | IPublicTypePropsList;
+
+  createSettingEntry(nodes: INode[]): ISettingTopEntry;
 }
 
 export class Designer implements IDesigner {
@@ -331,7 +338,7 @@ export class Designer implements IDesigner {
     this.oobxList.forEach((item) => item.compute());
   }
 
-  createSettingEntry(nodes: Node[]) {
+  createSettingEntry(nodes: INode[]): ISettingTopEntry {
     return new SettingTopEntry(this.editor, nodes);
   }
 

--- a/packages/designer/src/designer/detecting.ts
+++ b/packages/designer/src/designer/detecting.ts
@@ -4,8 +4,11 @@ import { IDocumentModel } from '../document/document-model';
 import { INode } from '../document/node/node';
 
 const DETECTING_CHANGE_EVENT = 'detectingChange';
-export interface IDetecting extends Omit< IPublicModelDetecting, 'capture' | 'release' | 'leave' > {
-
+export interface IDetecting extends Omit< IPublicModelDetecting<INode>,
+  'capture' |
+  'release' |
+  'leave'
+> {
   capture(node: INode | null): void;
 
   release(node: INode | null): void;

--- a/packages/designer/src/designer/location.ts
+++ b/packages/designer/src/designer/location.ts
@@ -1,7 +1,6 @@
-import { INode } from '../document';
+import { IDocumentModel, INode } from '../document';
 import { ILocateEvent } from './dragon';
 import {
-  IPublicModelDocumentModel,
   IPublicModelDropLocation,
   IPublicTypeLocationDetailType,
   IPublicTypeRect,
@@ -105,7 +104,7 @@ export interface IDropLocation extends Omit< IPublicModelDropLocation, 'target' 
 
   get target(): INode;
 
-  get document(): IPublicModelDocumentModel;
+  get document(): IDocumentModel | null;
 
   clone(event: IPublicModelLocateEvent): IDropLocation;
 }
@@ -119,7 +118,7 @@ export class DropLocation implements IDropLocation {
 
   readonly source: string;
 
-  get document(): IPublicModelDocumentModel {
+  get document(): IDocumentModel | null {
     return this.target.document;
   }
 
@@ -159,7 +158,7 @@ export class DropLocation implements IDropLocation {
       if (this.detail.index <= 0) {
         return null;
       }
-      return this.target.children.get(this.detail.index - 1);
+      return this.target.children?.get(this.detail.index - 1);
     }
     return (this.detail as any)?.near?.node;
   }

--- a/packages/designer/src/designer/setting/setting-entry.ts
+++ b/packages/designer/src/designer/setting/setting-entry.ts
@@ -3,15 +3,15 @@ import { IComponentMeta } from '../../component-meta';
 import { Designer } from '../designer';
 import { INode } from '../../document';
 
-export interface SettingEntry extends IPublicModelSettingTarget {
+export interface ISettingEntry extends IPublicModelSettingTarget {
   readonly nodes: INode[];
   readonly componentMeta: IComponentMeta | null;
   readonly designer: Designer;
 
   // 顶端
-  readonly top: SettingEntry;
+  readonly top: ISettingEntry;
   // 父级
-  readonly parent: SettingEntry;
+  readonly parent: ISettingEntry;
 
-  get: (propName: string | number) => SettingEntry | null;
+  get: (propName: string | number) => ISettingEntry | null;
 }

--- a/packages/designer/src/designer/setting/setting-field.ts
+++ b/packages/designer/src/designer/setting/setting-field.ts
@@ -9,11 +9,11 @@ import {
 } from '@alilc/lowcode-types';
 import { Transducer } from './utils';
 import { SettingPropEntry } from './setting-prop-entry';
-import { SettingEntry } from './setting-entry';
+import { ISettingEntry } from './setting-entry';
 import { computed, obx, makeObservable, action, untracked, intl } from '@alilc/lowcode-editor-core';
 import { cloneDeep, isCustomView, isDynamicSetter } from '@alilc/lowcode-utils';
 
-function getSettingFieldCollectorKey(parent: SettingEntry, config: IPublicTypeFieldConfig) {
+function getSettingFieldCollectorKey(parent: ISettingEntry, config: IPublicTypeFieldConfig) {
   let cur = parent;
   const path = [config.name];
   while (cur !== parent.top) {
@@ -25,7 +25,11 @@ function getSettingFieldCollectorKey(parent: SettingEntry, config: IPublicTypeFi
   return path.join('.');
 }
 
-export class SettingField extends SettingPropEntry implements SettingEntry {
+export interface ISettingField extends ISettingEntry {
+
+}
+
+export class SettingField extends SettingPropEntry implements ISettingField {
   readonly isSettingField = true;
 
   readonly isRequired: boolean;
@@ -36,7 +40,7 @@ export class SettingField extends SettingPropEntry implements SettingEntry {
 
   private hotValue: any;
 
-  parent: SettingEntry;
+  parent: ISettingEntry;
 
   extraProps: IPublicTypeFieldExtraProps;
 
@@ -56,7 +60,7 @@ export class SettingField extends SettingPropEntry implements SettingEntry {
   private _items: Array<SettingField | IPublicTypeCustomView> = [];
 
   constructor(
-    parent: SettingEntry,
+    parent: ISettingEntry,
     config: IPublicTypeFieldConfig,
     private settingFieldCollector?: (name: string | number, field: SettingField) => void,
   ) {

--- a/packages/designer/src/designer/setting/setting-field.ts
+++ b/packages/designer/src/designer/setting/setting-field.ts
@@ -58,7 +58,7 @@ export class SettingField extends SettingPropEntry implements SettingEntry {
   constructor(
     parent: SettingEntry,
     config: IPublicTypeFieldConfig,
-    settingFieldCollector?: (name: string | number, field: SettingField) => void,
+    private settingFieldCollector?: (name: string | number, field: SettingField) => void,
   ) {
     super(parent, config.name, config.type);
     makeObservable(this);
@@ -137,7 +137,8 @@ export class SettingField extends SettingPropEntry implements SettingEntry {
 
   // 创建子配置项，通常用于 object/array 类型数据
   createField(config: IPublicTypeFieldConfig): SettingField {
-    return new SettingField(this, config);
+    this.settingFieldCollector?.(getSettingFieldCollectorKey(this.parent, config), this);
+    return new SettingField(this, config, this.settingFieldCollector);
   }
 
   purge() {

--- a/packages/designer/src/designer/setting/setting-prop-entry.ts
+++ b/packages/designer/src/designer/setting/setting-prop-entry.ts
@@ -2,13 +2,13 @@ import { obx, computed, makeObservable, runInAction, IEventBus, createModuleEven
 import { GlobalEvent, IPublicModelEditor, IPublicTypeSetValueOptions } from '@alilc/lowcode-types';
 import { uniqueId, isJSExpression, isSettingField } from '@alilc/lowcode-utils';
 import { Setters } from '@alilc/lowcode-shell';
-import { SettingEntry } from './setting-entry';
+import { ISettingEntry } from './setting-entry';
 import { INode } from '../../document';
 import { IComponentMeta } from '../../component-meta';
 import { Designer } from '../designer';
-import { SettingField } from './setting-field';
+import { ISettingField } from './setting-field';
 
-export class SettingPropEntry implements SettingEntry {
+export class SettingPropEntry implements ISettingEntry {
   // === static properties ===
   readonly editor: IPublicModelEditor;
 
@@ -26,7 +26,7 @@ export class SettingPropEntry implements SettingEntry {
 
   readonly designer: Designer;
 
-  readonly top: SettingEntry;
+  readonly top: ISettingEntry;
 
   readonly isGroup: boolean;
 
@@ -53,7 +53,7 @@ export class SettingPropEntry implements SettingEntry {
 
   extraProps: any = {};
 
-  constructor(readonly parent: SettingEntry | SettingField, name: string | number, type?: 'field' | 'group') {
+  constructor(readonly parent: ISettingEntry | ISettingField, name: string | number, type?: 'field' | 'group') {
     makeObservable(this);
     if (type == null) {
       const c = typeof name === 'string' ? name.slice(0, 1) : '';

--- a/packages/designer/src/designer/setting/setting-prop-entry.ts
+++ b/packages/designer/src/designer/setting/setting-prop-entry.ts
@@ -1,11 +1,12 @@
 import { obx, computed, makeObservable, runInAction, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor-core';
 import { GlobalEvent, IPublicModelEditor, IPublicTypeSetValueOptions } from '@alilc/lowcode-types';
 import { uniqueId, isJSExpression, isSettingField } from '@alilc/lowcode-utils';
+import { Setters } from '@alilc/lowcode-shell';
 import { SettingEntry } from './setting-entry';
 import { INode } from '../../document';
 import { IComponentMeta } from '../../component-meta';
 import { Designer } from '../designer';
-import { Setters } from '@alilc/lowcode-shell';
+import { SettingField } from './setting-field';
 
 export class SettingPropEntry implements SettingEntry {
   // === static properties ===
@@ -52,7 +53,7 @@ export class SettingPropEntry implements SettingEntry {
 
   extraProps: any = {};
 
-  constructor(readonly parent: SettingEntry, name: string | number, type?: 'field' | 'group') {
+  constructor(readonly parent: SettingEntry | SettingField, name: string | number, type?: 'field' | 'group') {
     makeObservable(this);
     if (type == null) {
       const c = typeof name === 'string' ? name.slice(0, 1) : '';

--- a/packages/designer/src/designer/setting/setting-top-entry.ts
+++ b/packages/designer/src/designer/setting/setting-top-entry.ts
@@ -4,19 +4,22 @@ import { computed, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor
 import { SettingEntry } from './setting-entry';
 import { SettingField } from './setting-field';
 import { SettingPropEntry } from './setting-prop-entry';
-import { Node } from '../../document';
+import { INode } from '../../document';
 import { ComponentMeta } from '../../component-meta';
-import { Designer } from '../designer';
+import { IDesigner } from '../designer';
 import { Setters } from '@alilc/lowcode-shell';
 
-function generateSessionId(nodes: Node[]) {
+function generateSessionId(nodes: INode[]) {
   return nodes
     .map((node) => node.id)
     .sort()
     .join(',');
 }
 
-export class SettingTopEntry implements SettingEntry {
+export interface ISettingTopEntry extends SettingEntry {
+}
+
+export class SettingTopEntry implements ISettingTopEntry {
   private emitter: IEventBus = createModuleEventBus('SettingTopEntry');
 
   private _items: Array<SettingField | IPublicTypeCustomView> = [];
@@ -68,21 +71,21 @@ export class SettingTopEntry implements SettingEntry {
 
   readonly id: string;
 
-  readonly first: Node;
+  readonly first: INode;
 
-  readonly designer: Designer;
+  readonly designer: IDesigner | undefined;
 
   readonly setters: Setters;
 
   disposeFunctions: any[] = [];
 
-  constructor(readonly editor: IPublicModelEditor, readonly nodes: Node[]) {
+  constructor(readonly editor: IPublicModelEditor, readonly nodes: INode[]) {
     if (!Array.isArray(nodes) || nodes.length < 1) {
       throw new ReferenceError('nodes should not be empty');
     }
     this.id = generateSessionId(nodes);
     this.first = nodes[0];
-    this.designer = this.first.document.designer;
+    this.designer = this.first.document?.designer;
     this.setters = editor.get('setters') as Setters;
 
     // setups
@@ -228,7 +231,6 @@ export class SettingTopEntry implements SettingEntry {
     this.disposeFunctions.forEach(f => f());
     this.disposeFunctions = [];
   }
-
 
   getProp(propName: string | number) {
     return this.get(propName);

--- a/packages/designer/src/designer/setting/setting-top-entry.ts
+++ b/packages/designer/src/designer/setting/setting-top-entry.ts
@@ -1,7 +1,7 @@
 import { IPublicTypeCustomView, IPublicModelEditor } from '@alilc/lowcode-types';
 import { isCustomView } from '@alilc/lowcode-utils';
 import { computed, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor-core';
-import { SettingEntry } from './setting-entry';
+import { ISettingEntry } from './setting-entry';
 import { SettingField } from './setting-field';
 import { SettingPropEntry } from './setting-prop-entry';
 import { INode } from '../../document';
@@ -16,7 +16,7 @@ function generateSessionId(nodes: INode[]) {
     .join(',');
 }
 
-export interface ISettingTopEntry extends SettingEntry {
+export interface ISettingTopEntry extends ISettingEntry {
 }
 
 export class SettingTopEntry implements ISettingTopEntry {

--- a/packages/designer/src/document/document-model.ts
+++ b/packages/designer/src/document/document-model.ts
@@ -1,4 +1,13 @@
-import { makeObservable, obx, engineConfig, action, runWithGlobalEventOff, wrapWithEventSwitch, createModuleEventBus, IEventBus } from '@alilc/lowcode-editor-core';
+import {
+  makeObservable,
+  obx,
+  engineConfig,
+  action,
+  runWithGlobalEventOff,
+  wrapWithEventSwitch,
+  createModuleEventBus,
+  IEventBus,
+} from '@alilc/lowcode-editor-core';
 import {
   IPublicTypeNodeData,
   IPublicTypeNodeSchema,
@@ -8,20 +17,32 @@ import {
   IPublicTypeDragNodeObject,
   IPublicTypeDragNodeDataObject,
   IPublicModelDocumentModel,
-  IPublicModelHistory,
-  IPublicModelNode,
   IPublicEnumTransformStage,
   IPublicTypeOnChangeOptions,
+  IPublicTypeDisposable,
 } from '@alilc/lowcode-types';
+import {
+  IDropLocation,
+} from '@alilc/lowcode-designer';
+import {
+  uniqueId,
+  isPlainObject,
+  compatStage,
+  isJSExpression,
+  isDOMText,
+  isNodeSchema,
+  isDragNodeObject,
+  isDragNodeDataObject,
+  isNode,
+} from '@alilc/lowcode-utils';
 import { IProject, Project } from '../project';
 import { ISimulatorHost } from '../simulator';
-import { ComponentMeta } from '../component-meta';
-import { IDropLocation, Designer, IHistory } from '../designer';
-import { Node, insertChildren, insertChild, RootNode, INode } from './node/node';
+import { IComponentMeta } from '../component-meta';
+import { IDesigner, IHistory } from '../designer';
+import { insertChildren, insertChild, RootNode, INode } from './node/node';
 import { Selection, ISelection } from './selection';
 import { History } from './history';
-import { IModalNodesManager, ModalNodesManager } from './node';
-import { uniqueId, isPlainObject, compatStage, isJSExpression, isDOMText, isNodeSchema, isDragNodeObject, isDragNodeDataObject, isNode } from '@alilc/lowcode-utils';
+import { IModalNodesManager, ModalNodesManager, Node } from './node';
 import { EDITOR_EVENT } from '../types';
 
 export type GetDataType<T, NodeType> = T extends undefined
@@ -32,21 +53,39 @@ export type GetDataType<T, NodeType> = T extends undefined
     : any
   : T;
 
-export interface IDocumentModel extends Omit< IPublicModelDocumentModel, 'selection' | 'checkNesting' > {
+export interface IDocumentModel extends Omit< IPublicModelDocumentModel<
+  ISelection,
+  IHistory,
+  INode | RootNode,
+  IDropLocation,
+  IModalNodesManager,
+  IProject
+>,
+  'detecting' |
+  'checkNesting' |
+  'getNodeById' |
+  // 以下属性在内部的 document 中不存在
+  'exportSchema' |
+  'importSchema' |
+  'onAddNode' |
+  'onRemoveNode' |
+  'onChangeDetecting' |
+  'onChangeSelection' |
+  'onMountNode' |
+  'onChangeNodeProp' |
+  'onImportSchema' |
+  'isDetectingNode' |
+  'onFocusNodeChanged' |
+  'onDropLocationChanged'
+> {
 
-  readonly designer: Designer;
+  readonly designer: IDesigner;
 
-  /**
-   * 选区控制
-   */
-  readonly selection: ISelection;
+  get rootNode(): INode | null;
 
-  readonly project: IProject;
+  get simulator(): ISimulatorHost | null;
 
-  /**
-   * 模态节点管理
-   */
-  readonly modalNodesManager: IModalNodesManager;
+  get active(): boolean;
 
   /**
    * 根据 id 获取节点
@@ -55,16 +94,26 @@ export interface IDocumentModel extends Omit< IPublicModelDocumentModel, 'select
 
   getHistory(): IHistory;
 
-  get focusNode(): INode | null;
-
-  get rootNode(): INode | null;
-
   checkNesting(
     dropTarget: INode,
     dragObject: IPublicTypeDragNodeObject | IPublicTypeNodeSchema | INode | IPublicTypeDragNodeDataObject,
   ): boolean;
 
   getNodeCount(): number;
+
+  nextId(possibleId: string | undefined): string;
+
+  import(schema: IPublicTypeRootSchema, checkId?: boolean): void;
+
+  export(stage: IPublicEnumTransformStage): IPublicTypeRootSchema | undefined;
+
+  onNodeCreate(func: (node: INode) => void): IPublicTypeDisposable;
+
+  onNodeDestroy(func: (node: INode) => void): IPublicTypeDisposable;
+
+  onChangeNodeVisible(fn: (node: INode, visible: boolean) => void): IPublicTypeDisposable;
+
+  addWillPurge(node: INode): void;
 }
 
 export class DocumentModel implements IDocumentModel {
@@ -86,20 +135,20 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 操作记录控制
    */
-  readonly history: IPublicModelHistory;
+  readonly history: IHistory;
 
   /**
    * 模态节点管理
    */
-  readonly modalNodesManager: IModalNodesManager;
+  modalNodesManager: IModalNodesManager;
 
-  private _nodesMap = new Map<string, IPublicModelNode>();
+  private _nodesMap = new Map<string, INode>();
 
   readonly project: IProject;
 
-  readonly designer: Designer;
+  readonly designer: IDesigner;
 
-  @obx.shallow private nodes = new Set<IPublicModelNode>();
+  @obx.shallow private nodes = new Set<INode>();
 
   private seqId = 0;
 
@@ -119,7 +168,7 @@ export class DocumentModel implements IDocumentModel {
     return this.project.simulator;
   }
 
-  get nodesMap(): Map<string, Node> {
+  get nodesMap(): Map<string, INode> {
     return this._nodesMap;
   }
 
@@ -131,7 +180,7 @@ export class DocumentModel implements IDocumentModel {
     this.rootNode?.getExtraProp('fileName', true)?.setValue(fileName);
   }
 
-  get focusNode(): INode {
+  get focusNode(): INode | null {
     if (this._drillDownNode) {
       return this._drillDownNode;
     }
@@ -142,7 +191,7 @@ export class DocumentModel implements IDocumentModel {
     return this.rootNode;
   }
 
-  @obx.ref private _drillDownNode: Node | null = null;
+  @obx.ref private _drillDownNode: INode | null = null;
 
   private _modalNode?: INode;
 
@@ -150,7 +199,7 @@ export class DocumentModel implements IDocumentModel {
 
   private inited = false;
 
-  @obx.shallow private willPurgeSpace: Node[] = [];
+  @obx.shallow private willPurgeSpace: INode[] = [];
 
   get modalNode() {
     return this._modalNode;
@@ -160,7 +209,7 @@ export class DocumentModel implements IDocumentModel {
     return this.modalNode || this.focusNode;
   }
 
-  @obx.shallow private activeNodes?: Node[];
+  @obx.shallow private activeNodes?: INode[];
 
   @obx.ref private _dropLocation: IDropLocation | null = null;
 
@@ -236,7 +285,7 @@ export class DocumentModel implements IDocumentModel {
     // 兼容 vision
     this.id = project.getSchema()?.id || this.id;
 
-    this.rootNode = this.createNode<RootNode>(
+    this.rootNode = this.createNode(
       schema || {
         componentName: 'Page',
         id: 'root',
@@ -257,11 +306,11 @@ export class DocumentModel implements IDocumentModel {
     this.inited = true;
   }
 
-  drillDown(node: Node | null) {
+  drillDown(node: INode | null) {
     this._drillDownNode = node;
   }
 
-  onChangeNodeVisible(fn: (node: IPublicModelNode, visible: boolean) => void): () => void {
+  onChangeNodeVisible(fn: (node: INode, visible: boolean) => void): IPublicTypeDisposable {
     this.designer.editor?.eventBus.on(EDITOR_EVENT.NODE_CHILDREN_CHANGE, fn);
 
     return () => {
@@ -269,7 +318,7 @@ export class DocumentModel implements IDocumentModel {
     };
   }
 
-  onChangeNodeChildren(fn: (info: IPublicTypeOnChangeOptions) => void): () => void {
+  onChangeNodeChildren(fn: (info: IPublicTypeOnChangeOptions) => void): IPublicTypeDisposable {
     this.designer.editor?.eventBus.on(EDITOR_EVENT.NODE_VISIBLE_CHANGE, fn);
 
     return () => {
@@ -277,11 +326,11 @@ export class DocumentModel implements IDocumentModel {
     };
   }
 
-  addWillPurge(node: Node) {
+  addWillPurge(node: INode) {
     this.willPurgeSpace.push(node);
   }
 
-  removeWillPurge(node: Node) {
+  removeWillPurge(node: INode) {
     const i = this.willPurgeSpace.indexOf(node);
     if (i > -1) {
       this.willPurgeSpace.splice(i, 1);
@@ -295,7 +344,7 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 生成唯一 id
    */
-  nextId(possibleId: string | undefined) {
+  nextId(possibleId: string | undefined): string {
     let id = possibleId;
     while (!id || this.nodesMap.get(id)) {
       id = `node_${(String(this.id).slice(-10) + (++this.seqId).toString(36)).toLocaleLowerCase()}`;
@@ -330,7 +379,7 @@ export class DocumentModel implements IDocumentModel {
    * 根据 schema 创建一个节点
    */
   @action
-  createNode<T extends Node = Node, C = undefined>(data: GetDataType<C, T>, checkId: boolean = true): T {
+  createNode<T extends INode = INode, C = undefined>(data: GetDataType<C, T>, checkId: boolean = true): T {
     let schema: any;
     if (isDOMText(data) || isJSExpression(data)) {
       schema = {
@@ -341,7 +390,7 @@ export class DocumentModel implements IDocumentModel {
       schema = data;
     }
 
-    let node: Node | null = null;
+    let node: INode | null = null;
     if (this.hasNode(schema?.id)) {
       schema.id = null;
     }
@@ -373,30 +422,30 @@ export class DocumentModel implements IDocumentModel {
     return node as any;
   }
 
-  public destroyNode(node: Node) {
+  public destroyNode(node: INode) {
     this.emitter.emit('nodedestroy', node);
   }
 
   /**
    * 插入一个节点
    */
-  insertNode(parent: INode, thing: Node | IPublicTypeNodeData, at?: number | null, copy?: boolean): Node {
+  insertNode(parent: INode, thing: INode | IPublicTypeNodeData, at?: number | null, copy?: boolean): INode {
     return insertChild(parent, thing, at, copy);
   }
 
   /**
    * 插入多个节点
    */
-  insertNodes(parent: INode, thing: Node[] | IPublicTypeNodeData[], at?: number | null, copy?: boolean) {
+  insertNodes(parent: INode, thing: INode[] | IPublicTypeNodeData[], at?: number | null, copy?: boolean) {
     return insertChildren(parent, thing, at, copy);
   }
 
   /**
    * 移除一个节点
    */
-  removeNode(idOrNode: string | Node) {
+  removeNode(idOrNode: string | INode) {
     let id: string;
-    let node: Node | null;
+    let node: INode | null;
     if (typeof idOrNode === 'string') {
       id = idOrNode;
       node = this.getNode(id);
@@ -413,14 +462,14 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 内部方法，请勿调用
    */
-  internalRemoveAndPurgeNode(node: Node, useMutator = false) {
+  internalRemoveAndPurgeNode(node: INode, useMutator = false) {
     if (!this.nodes.has(node)) {
       return;
     }
     node.remove(useMutator);
   }
 
-  unlinkNode(node: Node) {
+  unlinkNode(node: INode) {
     this.nodes.delete(node);
     this._nodesMap.delete(node.id);
   }
@@ -428,7 +477,7 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 包裹当前选区中的节点
    */
-  wrapWith(schema: IPublicTypeNodeSchema): Node | null {
+  wrapWith(schema: IPublicTypeNodeSchema): INode | null {
     const nodes = this.selection.getTopNodes();
     if (nodes.length < 1) {
       return null;
@@ -465,17 +514,17 @@ export class DocumentModel implements IDocumentModel {
     });
   }
 
-  export(stage: IPublicEnumTransformStage = IPublicEnumTransformStage.Serilize) {
+  export(stage: IPublicEnumTransformStage = IPublicEnumTransformStage.Serilize): IPublicTypeRootSchema | undefined {
     stage = compatStage(stage);
     // 置顶只作用于 Page 的第一级子节点，目前还用不到里层的置顶；如果后面有需要可以考虑将这段写到 node-children 中的 export
-    const currentSchema = this.rootNode?.export(stage);
-    if (Array.isArray(currentSchema?.children) && currentSchema?.children.length > 0) {
-      const FixedTopNodeIndex = currentSchema.children
+    const currentSchema = this.rootNode?.export<IPublicTypeRootSchema>(stage);
+    if (Array.isArray(currentSchema?.children) && currentSchema?.children?.length && currentSchema?.children?.length > 0) {
+      const FixedTopNodeIndex = currentSchema?.children
         .filter(i => isPlainObject(i))
         .findIndex((i => (i as IPublicTypeNodeSchema).props?.__isTopFixed__));
       if (FixedTopNodeIndex > 0) {
-        const FixedTopNode = currentSchema.children.splice(FixedTopNodeIndex, 1);
-        currentSchema.children.unshift(FixedTopNode[0]);
+        const FixedTopNode = currentSchema?.children.splice(FixedTopNodeIndex, 1);
+        currentSchema?.children.unshift(FixedTopNode[0]);
       }
     }
     return currentSchema;
@@ -504,7 +553,7 @@ export class DocumentModel implements IDocumentModel {
     return this.simulator!.getComponent(componentName);
   }
 
-  getComponentMeta(componentName: string): ComponentMeta {
+  getComponentMeta(componentName: string): IComponentMeta {
     return this.designer.getComponentMeta(
       componentName,
       () => this.simulator?.generateComponentMetadata(componentName) || null,
@@ -579,10 +628,10 @@ export class DocumentModel implements IDocumentModel {
       dropTarget: INode,
       dragObject: IPublicTypeDragNodeObject | IPublicTypeNodeSchema | INode | IPublicTypeDragNodeDataObject,
     ): boolean {
-    let items: Array<Node | IPublicTypeNodeSchema>;
+    let items: Array<INode | IPublicTypeNodeSchema>;
     if (isDragNodeDataObject(dragObject)) {
       items = Array.isArray(dragObject.data) ? dragObject.data : [dragObject.data];
-    } else if (isDragNodeObject(dragObject)) {
+    } else if (isDragNodeObject<INode>(dragObject)) {
       items = dragObject.nodes;
     } else if (isNode(dragObject) || isNodeSchema(dragObject)) {
       items = [dragObject];
@@ -599,11 +648,13 @@ export class DocumentModel implements IDocumentModel {
    * Use checkNesting method instead.
    */
   checkDropTarget(dropTarget: INode, dragObject: IPublicTypeDragNodeObject | IPublicTypeDragNodeDataObject): boolean {
-    let items: Array<Node | IPublicTypeNodeSchema>;
+    let items: Array<INode | IPublicTypeNodeSchema>;
     if (isDragNodeDataObject(dragObject)) {
       items = Array.isArray(dragObject.data) ? dragObject.data : [dragObject.data];
-    } else {
+    } else if (isDragNodeObject<INode>(dragObject)) {
       items = dragObject.nodes;
+    } else {
+      return false;
     }
     return items.every((item) => this.checkNestingUp(dropTarget, item));
   }
@@ -611,7 +662,7 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 检查对象对父级的要求，涉及配置 parentWhitelist
    */
-  checkNestingUp(parent: INode, obj: IPublicTypeNodeSchema | Node): boolean {
+  checkNestingUp(parent: INode, obj: IPublicTypeNodeSchema | INode): boolean {
     if (isNode(obj) || isNodeSchema(obj)) {
       const config = isNode(obj) ? obj.componentMeta : this.getComponentMeta(obj.componentName);
       if (config) {
@@ -625,7 +676,7 @@ export class DocumentModel implements IDocumentModel {
   /**
    * 检查投放位置对子级的要求，涉及配置 childWhitelist
    */
-  checkNestingDown(parent: INode, obj: IPublicTypeNodeSchema | Node): boolean {
+  checkNestingDown(parent: INode, obj: IPublicTypeNodeSchema | INode): boolean {
     const config = parent.componentMeta;
     return config.checkNestingDown(parent, obj);
   }
@@ -666,7 +717,9 @@ export class DocumentModel implements IDocumentModel {
   */
   /* istanbul ignore next */
   exportAddonData() {
-    const addons = {};
+    const addons: {
+      [key: string]: any;
+    } = {};
     this._addons.forEach((addon) => {
       const data = addon.exportData();
       if (data === null) {

--- a/packages/designer/src/document/node/modal-nodes-manager.ts
+++ b/packages/designer/src/document/node/modal-nodes-manager.ts
@@ -1,9 +1,9 @@
-import { INode, Node } from './node';
+import { INode } from './node';
 import { DocumentModel } from '../document-model';
 import { IPublicModelModalNodesManager } from '@alilc/lowcode-types';
 import { createModuleEventBus, IEventBus } from '@alilc/lowcode-editor-core';
 
-export function getModalNodes(node: INode | Node) {
+export function getModalNodes(node: INode) {
   if (!node) return [];
   let nodes: any = [];
   if (node.componentMeta.isModal) {
@@ -18,11 +18,7 @@ export function getModalNodes(node: INode | Node) {
   return nodes;
 }
 
-export interface IModalNodesManager extends IPublicModelModalNodesManager {
-
-  getModalNodes(): INode[];
-
-  getVisibleModalNode(): INode | null;
+export interface IModalNodesManager extends IPublicModelModalNodesManager<INode> {
 }
 
 export class ModalNodesManager implements IModalNodesManager {

--- a/packages/designer/src/document/node/node-children.ts
+++ b/packages/designer/src/document/node/node-children.ts
@@ -54,6 +54,8 @@ export interface INodeChildren extends Omit<IPublicModelNodeChildren, 'forEach' 
 
   reduce(fn: (acc: any, cur: INode) => any, initialValue: any): void;
 
+  reverse(): INode[];
+
   mergeChildren(
     remover: (node: INode, idx: number) => boolean,
     adder: (children: INode[]) => IPublicTypeNodeData[] | null,
@@ -440,6 +442,10 @@ export class NodeChildren implements INodeChildren {
 
   reduce(fn: (acc: any, cur: INode) => any, initialValue: any): void {
     return this.children.reduce(fn, initialValue);
+  }
+
+  reverse() {
+    return this.children.reverse();
   }
 
   mergeChildren(

--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -401,7 +401,7 @@ export class Prop implements IProp, IPropParent {
       slotSchema = {
         componentName: 'Slot',
         title: value.title || value.props?.slotTitle,
-        id: data.id,
+        id: value.id,
         name: value.name || value.props?.slotName,
         params: value.params || value.props?.slotParams,
         children: value.children,

--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -2,7 +2,7 @@ import { untracked, computed, obx, engineConfig, action, makeObservable, mobx, r
 import { IPublicTypeCompositeValue, GlobalEvent, IPublicTypeJSSlot, IPublicTypeSlotSchema, IPublicEnumTransformStage, IPublicModelProp } from '@alilc/lowcode-types';
 import { uniqueId, isPlainObject, hasOwnProperty, compatStage, isJSExpression, isJSSlot } from '@alilc/lowcode-utils';
 import { valueToSource } from './value-to-source';
-import { Props, IProps, IPropParent } from './props';
+import { IProps, IPropParent } from './props';
 import { SlotNode, INode } from '../node';
 // import { TransformStage } from '../transform-stage';
 
@@ -13,7 +13,7 @@ export type UNSET = typeof UNSET;
 
 export interface IProp extends Omit<IPublicModelProp, 'exportSchema' | 'node' | 'slotNode' > {
 
-  readonly props: Props;
+  readonly props: IProps;
 
   readonly owner: INode;
 
@@ -24,6 +24,8 @@ export interface IProp extends Omit<IPublicModelProp, 'exportSchema' | 'node' | 
   export(stage: IPublicEnumTransformStage): IPublicTypeCompositeValue;
 
   getNode(): INode;
+
+  getAsString(): string;
 }
 
 export type ValueTypes = 'unset' | 'literal' | 'map' | 'list' | 'expression' | 'slot';
@@ -43,7 +45,7 @@ export class Prop implements IProp, IPropParent {
    */
   @obx spread: boolean;
 
-  readonly props: Props;
+  readonly props: IProps;
 
   readonly options: any;
 

--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -303,7 +303,7 @@ export class Prop implements IProp, IPropParent {
         return this._value;
       }
       const values = this.items!.map((prop) => {
-        return prop.export(stage);
+        return prop?.export(stage);
       });
       if (values.every((val) => val === undefined)) {
         return undefined;

--- a/packages/designer/src/document/node/props/props.ts
+++ b/packages/designer/src/document/node/props/props.ts
@@ -1,8 +1,8 @@
 import { computed, makeObservable, obx, action } from '@alilc/lowcode-editor-core';
-import { IPublicTypePropsMap, IPublicTypePropsList, IPublicTypeCompositeValue, IPublicEnumTransformStage, IPublicModelProps } from '@alilc/lowcode-types';
+import { IPublicTypePropsMap, IPublicTypePropsList, IPublicTypeCompositeValue, IPublicEnumTransformStage, IBaseModelProps } from '@alilc/lowcode-types';
 import { uniqueId, compatStage } from '@alilc/lowcode-utils';
 import { Prop, IProp, UNSET } from './prop';
-import { INode, Node } from '../node';
+import { INode } from '../node';
 // import { TransformStage } from '../transform-stage';
 
 interface ExtrasObject {
@@ -34,18 +34,24 @@ export interface IPropParent {
 
   delete(prop: Prop): void;
 
+  query(path: string, createIfNone: boolean): Prop | null;
 }
 
-export interface IProps extends Omit<IPublicModelProps, 'getProp' | 'getExtraProp' | 'getExtraPropValue' | 'setExtraPropValue' | 'node'> {
+export interface IProps extends Omit<IBaseModelProps<IProp>, | 'getExtraProp' | 'getExtraPropValue' | 'setExtraPropValue' | 'node'> {
 
   /**
    * 获取 props 对应的 node
    */
   getNode(): INode;
 
-  getProp(path: string): IProp | null;
+  get(path: string, createIfNone?: boolean): Prop | null;
 
-  get(path: string, createIfNone: boolean): Prop;
+  export(stage?: IPublicEnumTransformStage): {
+    props?: IPublicTypePropsMap | IPublicTypePropsList;
+    extras?: ExtrasObject;
+  };
+
+  merge(value: IPublicTypePropsMap, extras?: IPublicTypePropsMap): void;
 }
 
 export class Props implements IProps, IPropParent {

--- a/packages/designer/src/document/selection.ts
+++ b/packages/designer/src/document/selection.ts
@@ -1,20 +1,10 @@
 import { obx, makeObservable, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor-core';
-import { Node, INode, comparePosition, PositionNO } from './node/node';
+import { INode, comparePosition, PositionNO } from './node/node';
 import { DocumentModel } from './document-model';
 import { IPublicModelSelection } from '@alilc/lowcode-types';
 
-export interface ISelection extends Omit< IPublicModelSelection, 'getNodes' | 'getTopNodes' > {
+export interface ISelection extends Omit<IPublicModelSelection<INode>, 'node'> {
 
-  /**
-   * 获取选中的节点实例
-   * @returns
-   */
-  getNodes(): INode[];
-
-  /**
-   * 获取顶层选区节点，场景：拖拽时，建立蒙层，只蒙在最上层
-   */
-  getTopNodes(includeRoot?: boolean): INode[];
 }
 
 export class Selection implements ISelection {
@@ -115,7 +105,7 @@ export class Selection implements ISelection {
   /**
    * 选区是否包含节点
    */
-  containsNode(node: Node, excludeRoot = false) {
+  containsNode(node: INode, excludeRoot = false) {
     for (const id of this._selected) {
       const parent = this.doc.getNode(id);
       if (excludeRoot && parent?.contains(this.doc.focusNode)) {
@@ -131,8 +121,8 @@ export class Selection implements ISelection {
   /**
    * 获取选中的节点
    */
-  getNodes(): Node[] {
-    const nodes = [];
+  getNodes(): INode[] {
+    const nodes: INode[] = [];
     for (const id of this._selected) {
       const node = this.doc.getNode(id);
       if (node) {

--- a/packages/designer/src/plugin/plugin-context.ts
+++ b/packages/designer/src/plugin/plugin-context.ts
@@ -16,6 +16,7 @@ import {
   IPublicApiPlugins,
   IPublicTypePluginDeclaration,
   IPublicApiCanvas,
+  IPublicApiWorkspace,
 } from '@alilc/lowcode-types';
 import {
   IPluginContextOptions,
@@ -24,8 +25,8 @@ import {
 } from './plugin-types';
 import { isValidPreferenceKey } from './plugin-utils';
 
-
-export default class PluginContext implements IPublicModelPluginContext, ILowCodePluginContextPrivate {
+export default class PluginContext implements
+  IPublicModelPluginContext, ILowCodePluginContextPrivate {
   hotkey: IPublicApiHotkey;
   project: IPublicApiProject;
   skeleton: IPublicApiSkeleton;
@@ -39,6 +40,7 @@ export default class PluginContext implements IPublicModelPluginContext, ILowCod
   preference: IPluginPreferenceMananger;
   pluginEvent: IPublicApiEvent;
   canvas: IPublicApiCanvas;
+  workspace: IPublicApiWorkspace;
 
   constructor(
       options: IPluginContextOptions,

--- a/packages/designer/src/project/project.ts
+++ b/packages/designer/src/project/project.ts
@@ -12,13 +12,31 @@ import {
 import { isLowCodeComponentType, isProCodeComponentType } from '@alilc/lowcode-utils';
 import { ISimulatorHost } from '../simulator';
 
-export interface IProject extends Omit< IPublicApiProject, 'simulatorHost' | 'importSchema' | 'exportSchema' | 'openDocument' | 'getDocumentById' | 'getCurrentDocument' | 'addPropsTransducer' | 'onRemoveDocument' | 'onChangeDocument' | 'onSimulatorHostReady' | 'onSimulatorRendererReady' | 'setI18n' > {
+export interface IProject extends Omit< IPublicApiProject,
+  'simulatorHost' |
+  'importSchema' |
+  'exportSchema' |
+  'openDocument' |
+  'getDocumentById' |
+  'getCurrentDocument' |
+  'addPropsTransducer' |
+  'onRemoveDocument' |
+  'onChangeDocument' |
+  'onSimulatorHostReady' |
+  'onSimulatorRendererReady' |
+  'setI18n' |
+  'currentDocument' |
+  'selection' |
+  'documents' |
+  'createDocument' |
+  'getDocumentByFileName'
+> {
 
   get designer(): IDesigner;
 
   get simulator(): ISimulatorHost | null;
 
-  get currentDocument(): IDocumentModel | null;
+  get currentDocument(): IDocumentModel | null | undefined;
 
   get documents(): IDocumentModel[];
 
@@ -60,6 +78,8 @@ export interface IProject extends Omit< IPublicApiProject, 'simulatorHost' | 'im
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     value: any,
   ): void;
+
+  checkExclusive(activeDoc: DocumentModel): void;
 }
 
 export class Project implements IProject {
@@ -85,7 +105,7 @@ export class Project implements IProject {
     return this._simulator || null;
   }
 
-  @computed get currentDocument(): IDocumentModel | null {
+  @computed get currentDocument(): IDocumentModel | null | undefined {
     return this.documents.find((doc) => doc.active);
   }
 

--- a/packages/designer/src/simulator.ts
+++ b/packages/designer/src/simulator.ts
@@ -2,7 +2,7 @@ import { ComponentType } from 'react';
 import { IPublicTypeComponentMetadata, IPublicTypeNodeSchema, IPublicTypeScrollable, IPublicTypeComponentInstance, IPublicModelSensor, IPublicTypeNodeInstance } from '@alilc/lowcode-types';
 import { Point, ScrollTarget, ILocateEvent } from './designer';
 import { BuiltinSimulatorRenderer } from './builtin-simulator/renderer';
-import { Node, INode } from './document';
+import { INode } from './document';
 
 export type AutoFit = '100%';
 // eslint-disable-next-line no-redeclare
@@ -132,7 +132,7 @@ export interface ISimulatorHost<P = object> extends IPublicModelSensor {
   /**
    * 滚动视口到节点
    */
-  scrollToNode(node: Node, detail?: any): void;
+  scrollToNode(node: INode, detail?: any): void;
 
   /**
    * 描述组件
@@ -147,7 +147,7 @@ export interface ISimulatorHost<P = object> extends IPublicModelSensor {
   /**
    * 根据节点获取节点的组件实例
    */
-  getComponentInstances(node: Node): IPublicTypeComponentInstance[] | null;
+  getComponentInstances(node: INode): IPublicTypeComponentInstance[] | null;
 
   /**
    * 根据 schema 创建组件类
@@ -157,11 +157,11 @@ export interface ISimulatorHost<P = object> extends IPublicModelSensor {
   /**
    * 根据节点获取节点的组件运行上下文
    */
-  getComponentContext(node: Node): object | null;
+  getComponentContext(node: INode): object | null;
 
   getClosestNodeInstance(from: IPublicTypeComponentInstance, specId?: string): IPublicTypeNodeInstance | null;
 
-  computeRect(node: Node): DOMRect | null;
+  computeRect(node: INode): DOMRect | null;
 
   computeComponentInstanceRect(instance: IPublicTypeComponentInstance, selector?: string): DOMRect | null;
 
@@ -189,6 +189,6 @@ export function isSimulatorHost(obj: any): obj is ISimulatorHost {
 export type Component = ComponentType<any> | object;
 
 export interface INodeSelector {
-  node: Node;
+  node: INode;
   instance?: IPublicTypeComponentInstance;
 }

--- a/packages/designer/tests/document/node/props/prop.test.ts
+++ b/packages/designer/tests/document/node/props/prop.test.ts
@@ -499,6 +499,57 @@ describe('Prop 类测试', () => {
     expect(slotProp.purged).toBeTruthy();
     slotProp.dispose();
   });
+
+  describe('slotNode-value / setAsSlot', () => {
+    const editor = new Editor();
+    const designer = new Designer({ editor, shellModelFactory });
+    const doc = new DocumentModel(designer.project, {
+      componentName: 'Page',
+      children: [
+        {
+          id: 'div',
+          componentName: 'Div',
+        },
+      ],
+    });
+    const div = doc.getNode('div');
+
+    const slotProp = new Prop(div?.getProps(), {
+      type: 'JSSlot',
+      value: {
+        componentName: 'Slot',
+        props: {
+          slotName: "content",
+          slotTitle: "主内容"
+        },
+        children: [
+          {
+            componentName: 'Button',
+          }
+        ]
+      },
+    });
+
+    expect(slotProp.slotNode?.componentName).toBe('Slot');
+
+    expect(slotProp.slotNode?.title).toBe('主内容');
+    expect(slotProp.slotNode?.getExtraProp('name')?.getValue()).toBe('content');
+
+    slotProp.export();
+
+    // Save
+    expect(slotProp.export()?.value[0].componentName).toBe('Button');
+    expect(slotProp.export()?.title).toBe('主内容');
+    expect(slotProp.export()?.name).toBe('content');
+
+    // Render
+    expect(slotProp.export(IPublicEnumTransformStage.Render)?.value.children[0].componentName).toBe('Button');
+    expect(slotProp.export(IPublicEnumTransformStage.Render)?.value.componentName).toBe('Slot');
+
+    slotProp.purge();
+    expect(slotProp.purged).toBeTruthy();
+    slotProp.dispose();
+  });
 });
 
 describe('其他导出函数', () => {

--- a/packages/designer/tests/document/node/props/prop.test.ts
+++ b/packages/designer/tests/document/node/props/prop.test.ts
@@ -518,6 +518,7 @@ describe('Prop 类测试', () => {
       type: 'JSSlot',
       value: {
         componentName: 'Slot',
+        id: 'node_oclei5rv2e2',
         props: {
           slotName: "content",
           slotTitle: "主内容"
@@ -534,6 +535,7 @@ describe('Prop 类测试', () => {
 
     expect(slotProp.slotNode?.title).toBe('主内容');
     expect(slotProp.slotNode?.getExtraProp('name')?.getValue()).toBe('content');
+    expect(slotProp.slotNode?.export()?.id).toBe('node_oclei5rv2e2');
 
     slotProp.export();
 

--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -124,9 +124,7 @@ const VALID_ENGINE_OPTIONS = {
     type: 'array',
     description: '自定义 simulatorUrl 的地址',
   },
-  /**
-   * 与 react-renderer 的 appHelper 一致，https://lowcode-engine.cn/site/docs/guide/expand/runtime/renderer#apphelper
-   */
+  // 与 react-renderer 的 appHelper 一致，https://lowcode-engine.cn/site/docs/guide/expand/runtime/renderer#apphelper
   appHelper: {
     type: 'object',
     description: '定义 utils 和 constants 等对象',
@@ -149,7 +147,6 @@ const VALID_ENGINE_OPTIONS = {
   },
 };
 
-
 const getStrictModeValue = (engineOptions: IPublicTypeEngineOptions, defaultValue: boolean): boolean => {
   if (!engineOptions || !isPlainObject(engineOptions)) {
     return defaultValue;
@@ -161,7 +158,8 @@ const getStrictModeValue = (engineOptions: IPublicTypeEngineOptions, defaultValu
   return engineOptions.enableStrictPluginMode;
 };
 
-export interface IEngineConfigPrivate {
+export interface IEngineConfig extends IPublicModelEngineConfig {
+
   /**
    * if engineOptions.strictPluginMode === true, only accept propertied predefined in EngineOptions.
    *
@@ -176,8 +174,7 @@ export interface IEngineConfigPrivate {
   delWait(key: string, fn: any): void;
 }
 
-
-export class EngineConfig implements IPublicModelEngineConfig, IEngineConfigPrivate {
+export class EngineConfig implements IEngineConfig {
   private config: { [key: string]: any } = {};
 
   private waits = new Map<

--- a/packages/editor-core/src/config.ts
+++ b/packages/editor-core/src/config.ts
@@ -288,13 +288,11 @@ export class EngineConfig implements IEngineConfig {
     const val = this.config?.[key];
     if (val !== undefined) {
       fn(val);
-      return () => {};
-    } else {
-      this.setWait(key, fn);
-      return () => {
-        this.delWait(key, fn);
-      };
     }
+    this.setWait(key, fn);
+    return () => {
+      this.delWait(key, fn);
+    };
   }
 
   notifyGot(key: string): void {

--- a/packages/editor-core/src/editor.ts
+++ b/packages/editor-core/src/editor.ts
@@ -190,13 +190,11 @@ export class Editor extends (EventEmitter as any) implements IPublicModelEditor 
     const x = this.context.get(keyOrType);
     if (x !== undefined) {
       fn(x);
-      return () => { };
-    } else {
-      this.setWait(keyOrType, fn);
-      return () => {
-        this.delWait(keyOrType, fn);
-      };
     }
+    this.setWait(keyOrType, fn);
+    return () => {
+      this.delWait(keyOrType, fn);
+    };
   }
 
   register(data: any, key?: IPublicTypeEditorValueKey): void {

--- a/packages/editor-skeleton/src/components/settings/settings-pane.tsx
+++ b/packages/editor-skeleton/src/components/settings/settings-pane.tsx
@@ -3,7 +3,7 @@ import { shallowIntl, observer, obx, engineConfig, runInAction, globalContext } 
 import { createContent, isJSSlot, isSetterConfig, isSettingField } from '@alilc/lowcode-utils';
 import { Skeleton } from '@alilc/lowcode-editor-skeleton';
 import { IPublicTypeCustomView } from '@alilc/lowcode-types';
-import { SettingField, SettingTopEntry, SettingEntry, ComponentMeta } from '@alilc/lowcode-designer';
+import { SettingField, SettingTopEntry, ISettingEntry, ComponentMeta } from '@alilc/lowcode-designer';
 import { createField } from '../field';
 import PopupService, { PopupPipe } from '../popup';
 import { SkeletonContext } from '../../context';
@@ -58,7 +58,7 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
         stageName = `${field.getNode().id}_${field.name.toString()}`;
         // 清除原 stage，不然 content 引用的一直是老的 field，导致数据无法得到更新
         stages.container.remove(stageName);
-        const stage = stages.add({
+        stages.add({
           type: 'Widget',
           name: stageName,
           content: <Fragment>{field.items.map((item, index) => createSettingFieldView(item, field, index))}</Fragment>,
@@ -324,7 +324,7 @@ class SettingGroupView extends Component<SettingGroupViewProps> {
   }
 }
 
-export function createSettingFieldView(item: SettingField | IPublicTypeCustomView, field: SettingEntry, index?: number) {
+export function createSettingFieldView(item: SettingField | IPublicTypeCustomView, field: ISettingEntry, index?: number) {
   if (isSettingField(item)) {
     if (item.isGroup) {
       return <SettingGroupView field={item} key={item.id} />;

--- a/packages/engine/src/engine-core.ts
+++ b/packages/engine/src/engine-core.ts
@@ -43,6 +43,7 @@ import {
   Logger,
   Canvas,
   Workspace,
+  Config,
 } from '@alilc/lowcode-shell';
 import { isPlainObject } from '@alilc/lowcode-utils';
 import './modules/live-editing';
@@ -96,7 +97,7 @@ editor.set('project', project);
 editor.set('setters' as any, setters);
 editor.set('material', material);
 editor.set('innerHotkey', innerHotkey);
-const config = engineConfig;
+const config = new Config(engineConfig);
 const event = new Event(commonEvent, { prefix: 'common' });
 const logger = new Logger({ level: 'warn', bizName: 'common' });
 const common = new Common(editor, innerSkeleton);

--- a/packages/engine/src/modules/shell-model-factory.ts
+++ b/packages/engine/src/modules/shell-model-factory.ts
@@ -1,5 +1,5 @@
 import {
-  Node as InnerNode,
+  INode,
   SettingField as InnerSettingField,
 } from '@alilc/lowcode-designer';
 import { IShellModelFactory, IPublicModelNode, IPublicModelSettingPropEntry } from '@alilc/lowcode-types';
@@ -8,7 +8,7 @@ import {
   SettingPropEntry,
 } from '@alilc/lowcode-shell';
 class ShellModelFactory implements IShellModelFactory {
-  createNode(node: InnerNode | null | undefined): IPublicModelNode | null {
+  createNode(node: INode | null | undefined): IPublicModelNode | null {
     return Node.create(node);
   }
   createSettingPropEntry(prop: InnerSettingField): IPublicModelSettingPropEntry {

--- a/packages/react-simulator-renderer/src/renderer-view.tsx
+++ b/packages/react-simulator-renderer/src/renderer-view.tsx
@@ -170,7 +170,9 @@ class Renderer extends Component<{
     this.startTime = Date.now();
     this.schemaChangedSymbol = false;
 
-    if (!container.autoRender || isRendererDetached()) return null;
+    if (!container.autoRender || isRendererDetached()) {
+      return null;
+    }
 
     const { intl } = createIntl(locale);
 

--- a/packages/renderer-core/src/renderer/addon.tsx
+++ b/packages/renderer-core/src/renderer/addon.tsx
@@ -45,7 +45,7 @@ export default function addonRendererFactory(): IBaseRenderComponent {
       this.__initDataSource(props);
       this.open = this.open || (() => { });
       this.close = this.close || (() => { });
-      this.__excuteLifeCycleMethod('constructor', [...arguments]);
+      this.__executeLifeCycleMethod('constructor', [...arguments]);
     }
 
     async componentWillUnmount() {

--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -40,7 +40,7 @@ import isUseLoop from '../utils/is-use-loop';
  * execute method in schema.lifeCycles with context
  * @PRIVATE
  */
-export function excuteLifeCycleMethod(context: any, schema: IPublicTypeNodeSchema, method: string, args: any, thisRequiredInJSE: boolean | undefined): any {
+export function executeLifeCycleMethod(context: any, schema: IPublicTypeNodeSchema, method: string, args: any, thisRequiredInJSE: boolean | undefined): any {
   if (!context || !isSchema(schema) || !method) {
     return;
   }
@@ -183,32 +183,32 @@ export default function baseRendererFactory(): IBaseRenderComponent {
     __afterInit(_props: IBaseRendererProps) { }
 
     static getDerivedStateFromProps(props: IBaseRendererProps, state: any) {
-      return excuteLifeCycleMethod(this, props?.__schema, 'getDerivedStateFromProps', [props, state], props.thisRequiredInJSE);
+      return executeLifeCycleMethod(this, props?.__schema, 'getDerivedStateFromProps', [props, state], props.thisRequiredInJSE);
     }
 
     async getSnapshotBeforeUpdate(...args: any[]) {
-      this.__excuteLifeCycleMethod('getSnapshotBeforeUpdate', args);
+      this.__executeLifeCycleMethod('getSnapshotBeforeUpdate', args);
       this.__debug(`getSnapshotBeforeUpdate - ${this.props?.__schema?.fileName}`);
     }
 
     async componentDidMount(...args: any[]) {
       this.reloadDataSource();
-      this.__excuteLifeCycleMethod('componentDidMount', args);
+      this.__executeLifeCycleMethod('componentDidMount', args);
       this.__debug(`componentDidMount - ${this.props?.__schema?.fileName}`);
     }
 
     async componentDidUpdate(...args: any[]) {
-      this.__excuteLifeCycleMethod('componentDidUpdate', args);
+      this.__executeLifeCycleMethod('componentDidUpdate', args);
       this.__debug(`componentDidUpdate - ${this.props.__schema.fileName}`);
     }
 
     async componentWillUnmount(...args: any[]) {
-      this.__excuteLifeCycleMethod('componentWillUnmount', args);
+      this.__executeLifeCycleMethod('componentWillUnmount', args);
       this.__debug(`componentWillUnmount - ${this.props?.__schema?.fileName}`);
     }
 
     async componentDidCatch(...args: any[]) {
-      this.__excuteLifeCycleMethod('componentDidCatch', args);
+      this.__executeLifeCycleMethod('componentDidCatch', args);
       console.warn(args);
     }
 
@@ -248,8 +248,8 @@ export default function baseRendererFactory(): IBaseRenderComponent {
      * execute method in schema.lifeCycles
      * @PRIVATE
      */
-    __excuteLifeCycleMethod = (method: string, args?: any) => {
-      excuteLifeCycleMethod(this, this.props.__schema, method, args, this.props.thisRequiredInJSE);
+    __executeLifeCycleMethod = (method: string, args?: any) => {
+      executeLifeCycleMethod(this, this.props.__schema, method, args, this.props.thisRequiredInJSE);
     };
 
     /**
@@ -406,7 +406,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
 
     __render = () => {
       const schema = this.props.__schema;
-      this.__excuteLifeCycleMethod('render');
+      this.__executeLifeCycleMethod('render');
       this.__writeCss(this.props);
 
       const { engine } = this.context;

--- a/packages/renderer-core/src/renderer/block.tsx
+++ b/packages/renderer-core/src/renderer/block.tsx
@@ -13,7 +13,7 @@ export default function blockRendererFactory(): IBaseRenderComponent {
       const schema = props.__schema || {};
       this.state = this.__parseData(schema.state || {});
       this.__initDataSource(props);
-      this.__excuteLifeCycleMethod('constructor', [...arguments]);
+      this.__executeLifeCycleMethod('constructor', [...arguments]);
     }
 
     render() {

--- a/packages/renderer-core/src/renderer/component.tsx
+++ b/packages/renderer-core/src/renderer/component.tsx
@@ -15,7 +15,7 @@ export default function componentRendererFactory(): IBaseRenderComponent {
       const schema = props.__schema || {};
       this.state = this.__parseData(schema.state || {});
       this.__initDataSource(props);
-      this.__excuteLifeCycleMethod('constructor', arguments as any);
+      this.__executeLifeCycleMethod('constructor', arguments as any);
     }
 
     render() {

--- a/packages/renderer-core/src/renderer/page.tsx
+++ b/packages/renderer-core/src/renderer/page.tsx
@@ -15,7 +15,7 @@ export default function pageRendererFactory(): IBaseRenderComponent {
       const schema = props.__schema || {};
       this.state = this.__parseData(schema.state || {});
       this.__initDataSource(props);
-      this.__excuteLifeCycleMethod('constructor', [props, ...rest]);
+      this.__executeLifeCycleMethod('constructor', [props, ...rest]);
     }
 
     async componentDidUpdate(prevProps: IBaseRendererProps, _prevState: {}, snapshot: unknown) {
@@ -43,7 +43,6 @@ export default function pageRendererFactory(): IBaseRenderComponent {
         page: this,
       });
       this.__render();
-
 
       const { Page } = __components;
       if (Page) {

--- a/packages/renderer-core/src/types/index.ts
+++ b/packages/renderer-core/src/types/index.ts
@@ -281,7 +281,7 @@ export type IBaseRendererInstance = IGeneralComponent<
     __beforeInit(props: IBaseRendererProps): void;
     __init(props: IBaseRendererProps): void;
     __afterInit(props: IBaseRendererProps): void;
-    __excuteLifeCycleMethod(method: string, args?: any[]): void;
+    __executeLifeCycleMethod(method: string, args?: any[]): void;
     __bindCustomMethods(props: IBaseRendererProps): void;
     __generateCtx(ctx: Record<string, any>): void;
     __parseData(data: any, ctx?: any): any;

--- a/packages/renderer-core/tests/renderer/base.test.tsx
+++ b/packages/renderer-core/tests/renderer/base.test.tsx
@@ -121,7 +121,7 @@ describe('Base Render methods', () => {
   // it('should excute lifecycle.componentDidCatch when defined', () => {
   // });
 
-  // it('__excuteLifeCycleMethod should work', () => {
+  // it('__executeLifeCycleMethod should work', () => {
   // });
 
   // it('reloadDataSource should work', () => {

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -10,6 +10,7 @@ import {
   SettingPropEntry,
   SettingTopEntry,
   Clipboard,
+  Config,
 } from './model';
 import {
   Project,
@@ -61,4 +62,5 @@ export {
   Workspace,
   Clipboard,
   SimulatorHost,
+  Config,
 };

--- a/packages/shell/src/model/config.ts
+++ b/packages/shell/src/model/config.ts
@@ -1,0 +1,39 @@
+import { IPublicModelEngineConfig, IPublicModelPreference, IPublicTypeDisposable } from '@alilc/lowcode-types';
+import { configSymbol } from '../symbols';
+import { IEngineConfig } from '@alilc/lowcode-editor-core';
+
+export class Config implements IPublicModelEngineConfig {
+  private readonly [configSymbol]: IEngineConfig;
+
+  constructor(innerEngineConfig: IEngineConfig) {
+    this[configSymbol] = innerEngineConfig;
+  }
+
+  has(key: string): boolean {
+    return this[configSymbol].has(key);
+  }
+
+  get(key: string, defaultValue?: any): any {
+    return this[configSymbol].get(key, defaultValue);
+  }
+
+  set(key: string, value: any): void {
+    this[configSymbol].set(key, value);
+  }
+
+  setConfig(config: { [key: string]: any }): void {
+    this[configSymbol].setConfig(config);
+  }
+
+  onceGot(key: string): Promise<any> {
+    return this[configSymbol].onceGot(key);
+  }
+
+  onGot(key: string, fn: (data: any) => void): IPublicTypeDisposable {
+    return this[configSymbol].onGot(key, fn);
+  }
+
+  getPreference(): IPublicModelPreference {
+    return this[configSymbol].getPreference();
+  }
+}

--- a/packages/shell/src/model/document-model.ts
+++ b/packages/shell/src/model/document-model.ts
@@ -21,6 +21,7 @@ import {
   IPublicApiCanvas,
   IPublicTypeDisposable,
   IPublicModelEditor,
+  IPublicTypeNodeSchema,
 } from '@alilc/lowcode-types';
 import { isDragNodeObject } from '@alilc/lowcode-utils';
 import { Node as ShellNode } from './node';
@@ -195,7 +196,7 @@ export class DocumentModel implements IPublicModelDocumentModel {
    * @param data
    * @returns
    */
-  createNode(data: any): IPublicModelNode | null {
+  createNode(data: IPublicTypeNodeSchema): IPublicModelNode | null {
     return ShellNode.create(this[documentSymbol].createNode(data));
   }
 
@@ -289,7 +290,7 @@ export class DocumentModel implements IPublicModelDocumentModel {
    * @param fn
    */
   onChangeNodeVisible(fn: (node: IPublicModelNode, visible: boolean) => void): IPublicTypeDisposable {
-    return this[documentSymbol].onChangeNodeVisible((node: IPublicModelNode, visible: boolean) => {
+    return this[documentSymbol].onChangeNodeVisible((node: InnerNode, visible: boolean) => {
       fn(ShellNode.create(node)!, visible);
     });
   }

--- a/packages/shell/src/model/index.ts
+++ b/packages/shell/src/model/index.ts
@@ -19,3 +19,4 @@ export * from './active-tracker';
 export * from './plugin-instance';
 export * from './window';
 export * from './clipboard';
+export * from './config';

--- a/packages/shell/src/model/node-children.ts
+++ b/packages/shell/src/model/node-children.ts
@@ -130,6 +130,15 @@ export class NodeChildren implements IPublicModelNodeChildren {
   }
 
   /**
+   * 类似数组的 reverse
+   */
+  reverse(): IPublicModelNode[] {
+    return this[nodeChildrenSymbol].reverse().map(d => {
+      return ShellNode.create(d)!;
+    });
+  }
+
+  /**
    * 类似数组的 map
    * @param fn
    */

--- a/packages/shell/src/model/node.ts
+++ b/packages/shell/src/model/node.ts
@@ -362,9 +362,9 @@ export class Node implements IPublicModelNode {
    * @param sorter
    */
   mergeChildren(
-    remover: (node: IPublicModelNode, idx: number) => boolean,
-    adder: (children: IPublicModelNode[]) => any,
-    sorter: (firstNode: IPublicModelNode, secondNode: IPublicModelNode) => number,
+    remover: (node: Node, idx: number) => boolean,
+    adder: (children: Node[]) => any,
+    sorter: (firstNode: Node, secondNode: Node) => number,
   ): any {
     return this.children?.mergeChildren(remover, adder, sorter);
   }

--- a/packages/shell/src/model/selection.ts
+++ b/packages/shell/src/model/selection.ts
@@ -1,14 +1,14 @@
 import {
   IDocumentModel as InnerDocumentModel,
   INode as InnerNode,
-  ISelection as InnerSelection,
+  ISelection,
 } from '@alilc/lowcode-designer';
 import { Node as ShellNode } from './node';
 import { selectionSymbol } from '../symbols';
 import { IPublicModelSelection, IPublicModelNode, IPublicTypeDisposable } from '@alilc/lowcode-types';
 
 export class Selection implements IPublicModelSelection {
-  private readonly [selectionSymbol]: InnerSelection;
+  private readonly [selectionSymbol]: ISelection;
 
   constructor(document: InnerDocumentModel) {
     this[selectionSymbol] = document.selection;

--- a/packages/shell/src/model/setting-prop-entry.ts
+++ b/packages/shell/src/model/setting-prop-entry.ts
@@ -1,4 +1,4 @@
-import { SettingField, SettingEntry } from '@alilc/lowcode-designer';
+import { SettingField, ISettingEntry } from '@alilc/lowcode-designer';
 import {
   IPublicTypeCompositeValue,
   IPublicTypeFieldConfig,
@@ -233,7 +233,7 @@ export class SettingPropEntry implements IPublicModelSettingPropEntry {
    * @returns
    */
   getProps(): IPublicModelSettingTopEntry {
-    return ShellSettingTopEntry.create(this[settingPropEntrySymbol].getProps() as SettingEntry);
+    return ShellSettingTopEntry.create(this[settingPropEntrySymbol].getProps() as ISettingEntry);
   }
 
   /**

--- a/packages/shell/src/model/setting-top-entry.ts
+++ b/packages/shell/src/model/setting-top-entry.ts
@@ -1,17 +1,17 @@
-import { SettingEntry } from '@alilc/lowcode-designer';
+import { ISettingEntry } from '@alilc/lowcode-designer';
 import { settingTopEntrySymbol } from '../symbols';
 import { Node as ShellNode } from './node';
 import { SettingPropEntry as ShellSettingPropEntry } from './setting-prop-entry';
 import { IPublicModelSettingTopEntry, IPublicModelNode, IPublicModelSettingPropEntry } from '@alilc/lowcode-types';
 
 export class SettingTopEntry implements IPublicModelSettingTopEntry {
-  private readonly [settingTopEntrySymbol]: SettingEntry;
+  private readonly [settingTopEntrySymbol]: ISettingEntry;
 
-  constructor(prop: SettingEntry) {
+  constructor(prop: ISettingEntry) {
     this[settingTopEntrySymbol] = prop;
   }
 
-  static create(prop: SettingEntry): IPublicModelSettingTopEntry {
+  static create(prop: ISettingEntry): IPublicModelSettingTopEntry {
     return new SettingTopEntry(prop);
   }
 

--- a/packages/shell/src/symbols.ts
+++ b/packages/shell/src/symbols.ts
@@ -32,3 +32,4 @@ export const pluginInstanceSymbol = Symbol('plugin-instance');
 export const resourceTypeSymbol = Symbol('resourceType');
 export const resourceSymbol = Symbol('resource');
 export const clipboardSymbol = Symbol('clipboard');
+export const configSymbol = Symbol('configSymbol');

--- a/packages/types/src/shell/model/component-meta.ts
+++ b/packages/types/src/shell/model/component-meta.ts
@@ -2,7 +2,9 @@ import { IPublicTypeNodeSchema, IPublicTypeNodeData, IPublicTypeIconType, IPubli
 import { ReactElement } from 'react';
 import { IPublicModelNode } from './node';
 
-export interface IPublicModelComponentMeta {
+export interface IPublicModelComponentMeta<
+  Node = IPublicModelNode
+> {
 
   /**
    * 组件名
@@ -92,7 +94,7 @@ export interface IPublicModelComponentMeta {
    * @param my 当前节点
    * @param parent 父节点
    */
-  checkNestingUp(my: IPublicModelNode | IPublicTypeNodeData, parent: any): boolean;
+  checkNestingUp(my: Node | IPublicTypeNodeData, parent: any): boolean;
 
   /**
    * 检测目标节点是否可被放置在父节点中
@@ -101,8 +103,8 @@ export interface IPublicModelComponentMeta {
    * @param parent 父节点
    */
   checkNestingDown(
-      my: IPublicModelNode | IPublicTypeNodeData,
-      target: IPublicTypeNodeSchema | IPublicModelNode | IPublicTypeNodeSchema[],
+      my: Node | IPublicTypeNodeData,
+      target: IPublicTypeNodeSchema | Node | IPublicTypeNodeSchema[],
     ): boolean;
 
   /**

--- a/packages/types/src/shell/model/detecting.ts
+++ b/packages/types/src/shell/model/detecting.ts
@@ -1,7 +1,7 @@
 import { IPublicModelNode } from './';
 import { IPublicTypeDisposable } from '../type';
 
-export interface IPublicModelDetecting {
+export interface IPublicModelDetecting<Node = IPublicModelNode> {
 
   /**
    * 是否启用
@@ -15,7 +15,7 @@ export interface IPublicModelDetecting {
    * get current hovering node
    * @since v1.0.16
    */
-  get current(): IPublicModelNode | null;
+  get current(): Node | null;
 
   /**
    * hover 指定节点
@@ -42,5 +42,5 @@ export interface IPublicModelDetecting {
    * set callback which will be called when hovering object changed.
    * @since v1.1.0
    */
-  onDetectingChange(fn: (node: IPublicModelNode | null) => void): IPublicTypeDisposable;
+  onDetectingChange(fn: (node: Node | null) => void): IPublicTypeDisposable;
 }

--- a/packages/types/src/shell/model/document-model.ts
+++ b/packages/types/src/shell/model/document-model.ts
@@ -2,15 +2,22 @@ import { IPublicTypeRootSchema, IPublicTypeDragNodeDataObject, IPublicTypeDragNo
 import { IPublicEnumTransformStage } from '../enum';
 import { IPublicApiProject } from '../api';
 import { IPublicModelDropLocation, IPublicModelDetecting, IPublicModelNode, IPublicModelSelection, IPublicModelHistory, IPublicModelModalNodesManager } from './';
-import { IPublicTypeOnChangeOptions } from '@alilc/lowcode-types';
+import { IPublicTypeNodeData, IPublicTypeNodeSchema, IPublicTypeOnChangeOptions } from '@alilc/lowcode-types';
 
-export interface IPublicModelDocumentModel {
+export interface IPublicModelDocumentModel<
+  Selection = IPublicModelSelection,
+  History = IPublicModelHistory,
+  Node = IPublicModelNode,
+  DropLocation = IPublicModelDropLocation,
+  ModalNodesManager = IPublicModelModalNodesManager,
+  Project = IPublicApiProject
+> {
 
   /**
      * 节点选中区模型实例
      * instance of selection
      */
-  selection: IPublicModelSelection;
+  selection: Selection;
 
   /**
    * 画布节点 hover 区模型实例
@@ -22,7 +29,7 @@ export interface IPublicModelDocumentModel {
    * 操作历史模型实例
    * instance of history
    */
-  history: IPublicModelHistory;
+  history: History;
 
   /**
    * id
@@ -36,30 +43,30 @@ export interface IPublicModelDocumentModel {
    * get project which this documentModel belongs to
    * @returns
    */
-  get project(): IPublicApiProject;
+  get project(): Project;
 
   /**
    * 获取文档的根节点
    * root node of this documentModel
    * @returns
    */
-  get root(): IPublicModelNode | null;
+  get root(): Node | null;
 
-  get focusNode(): IPublicModelNode | null;
+  get focusNode(): Node | null;
 
-  set focusNode(node: IPublicModelNode | null);
+  set focusNode(node: Node | null);
 
   /**
    * 获取文档下所有节点
    * @returns
    */
-  get nodesMap(): Map<string, IPublicModelNode>;
+  get nodesMap(): Map<string, Node>;
 
   /**
    * 模态节点管理
    * get instance of modalNodesManager
    */
-  get modalNodesManager(): IPublicModelModalNodesManager | null;
+  get modalNodesManager(): ModalNodesManager | null;
 
   /**
    * 根据 nodeId 返回 Node 实例
@@ -67,7 +74,7 @@ export interface IPublicModelDocumentModel {
    * @param nodeId
    * @returns
    */
-  getNodeById(nodeId: string): IPublicModelNode | null;
+  getNodeById(nodeId: string): Node | null;
 
   /**
    * 导入 schema
@@ -89,11 +96,11 @@ export interface IPublicModelDocumentModel {
    * insert a node
    */
   insertNode(
-    parent: IPublicModelNode,
-    thing: IPublicModelNode,
+    parent: Node,
+    thing: Node | IPublicTypeNodeData,
     at?: number | null | undefined,
     copy?: boolean | undefined
-  ): IPublicModelNode | null;
+  ): Node | null;
 
   /**
    * 创建一个节点
@@ -101,14 +108,14 @@ export interface IPublicModelDocumentModel {
    * @param data
    * @returns
    */
-  createNode(data: any): IPublicModelNode | null;
+  createNode(data: IPublicTypeNodeSchema): Node | null;
 
   /**
    * 移除指定节点/节点id
    * remove a node by node instance or nodeId
    * @param idOrNode
    */
-  removeNode(idOrNode: string | IPublicModelNode): void;
+  removeNode(idOrNode: string | Node): void;
 
   /**
    * componentsMap of documentModel
@@ -126,7 +133,7 @@ export interface IPublicModelDocumentModel {
    * @since v1.0.16
    */
   checkNesting(
-    dropTarget: IPublicModelNode,
+    dropTarget: Node,
     dragObject: IPublicTypeDragNodeObject | IPublicTypeDragNodeDataObject
   ): boolean;
 
@@ -134,26 +141,26 @@ export interface IPublicModelDocumentModel {
    * 当前 document 新增节点事件
    * set callback for event on node is created for a document
    */
-  onAddNode(fn: (node: IPublicModelNode) => void): IPublicTypeDisposable;
+  onAddNode(fn: (node: Node) => void): IPublicTypeDisposable;
 
   /**
    * 当前 document 新增节点事件，此时节点已经挂载到 document 上
    * set callback for event on node is mounted to canvas
    */
-  onMountNode(fn: (payload: { node: IPublicModelNode }) => void): IPublicTypeDisposable;
+  onMountNode(fn: (payload: { node: Node }) => void): IPublicTypeDisposable;
 
   /**
    * 当前 document 删除节点事件
    * set callback for event on node is removed
    */
-  onRemoveNode(fn: (node: IPublicModelNode) => void): IPublicTypeDisposable;
+  onRemoveNode(fn: (node: Node) => void): IPublicTypeDisposable;
 
   /**
    * 当前 document 的 hover 变更事件
    *
    * set callback for event on detecting changed
    */
-  onChangeDetecting(fn: (node: IPublicModelNode) => void): IPublicTypeDisposable;
+  onChangeDetecting(fn: (node: Node) => void): IPublicTypeDisposable;
 
   /**
    * 当前 document 的选中变更事件
@@ -166,7 +173,7 @@ export interface IPublicModelDocumentModel {
    * set callback for event on visibility changed for certain node
    * @param fn
    */
-  onChangeNodeVisible(fn: (node: IPublicModelNode, visible: boolean) => void): IPublicTypeDisposable;
+  onChangeNodeVisible(fn: (node: Node, visible: boolean) => void): IPublicTypeDisposable;
 
   /**
    * 当前 document 的节点 children 变更事件
@@ -193,21 +200,21 @@ export interface IPublicModelDocumentModel {
    * @param node
    * @since v1.1.0
    */
-  isDetectingNode(node: IPublicModelNode): boolean;
+  isDetectingNode(node: Node): boolean;
 
   /**
    * 获取当前的 DropLocation 信息
    * get current drop location
    * @since v1.1.0
    */
-  get dropLocation(): IPublicModelDropLocation | null;
+  get dropLocation(): DropLocation | null;
 
   /**
    * 设置当前的 DropLocation 信息
    * set current drop location
    * @since v1.1.0
    */
-  set dropLocation(loc: IPublicModelDropLocation | null);
+  set dropLocation(loc: DropLocation | null);
 
   /**
    * 设置聚焦节点变化的回调
@@ -216,7 +223,7 @@ export interface IPublicModelDocumentModel {
    * @since v1.1.0
    */
   onFocusNodeChanged(
-    fn: (doc: IPublicModelDocumentModel, focusNode: IPublicModelNode) => void,
+    fn: (doc: IPublicModelDocumentModel, focusNode: Node) => void,
   ): IPublicTypeDisposable;
 
   /**

--- a/packages/types/src/shell/model/engine-config.ts
+++ b/packages/types/src/shell/model/engine-config.ts
@@ -1,3 +1,4 @@
+import { IPublicTypeDisposable } from '../type';
 import { IPublicModelPreference } from './';
 
 export interface IPublicModelEngineConfig {
@@ -52,7 +53,7 @@ export interface IPublicModelEngineConfig {
    * @param fn
    * @returns
    */
-  onGot(key: string, fn: (data: any) => void): () => void;
+  onGot(key: string, fn: (data: any) => void): IPublicTypeDisposable;
 
   /**
    * 获取全局 Preference, 用于管理全局浏览器侧用户 Preference，如 Panel 是否钉住

--- a/packages/types/src/shell/model/modal-nodes-manager.ts
+++ b/packages/types/src/shell/model/modal-nodes-manager.ts
@@ -1,6 +1,6 @@
 import { IPublicModelNode } from './';
 
-export interface IPublicModelModalNodesManager {
+export interface IPublicModelModalNodesManager<Node = IPublicModelNode> {
 
   /**
    * 设置模态节点，触发内部事件
@@ -12,13 +12,13 @@ export interface IPublicModelModalNodesManager {
    * 获取模态节点（们）
    * get modal nodes
    */
-  getModalNodes(): IPublicModelNode[];
+  getModalNodes(): Node[];
 
   /**
    * 获取当前可见的模态节点
    * get current visible modal node
    */
-  getVisibleModalNode(): IPublicModelNode | null;
+  getVisibleModalNode(): Node | null;
 
   /**
    * 隐藏模态节点（们）
@@ -31,12 +31,12 @@ export interface IPublicModelModalNodesManager {
    * set specfic model node as visible
    * @param node Node
    */
-  setVisible(node: IPublicModelNode): void;
+  setVisible(node: Node): void;
 
   /**
    * 设置指定节点为不可见态
    * set specfic model node as invisible
    * @param node Node
    */
-  setInvisible(node: IPublicModelNode): void;
+  setInvisible(node: Node): void;
 }

--- a/packages/types/src/shell/model/node-children.ts
+++ b/packages/types/src/shell/model/node-children.ts
@@ -2,13 +2,15 @@ import { IPublicTypeNodeSchema, IPublicTypeNodeData } from '../type';
 import { IPublicEnumTransformStage } from '../enum';
 import { IPublicModelNode } from './';
 
-export interface IPublicModelNodeChildren {
+export interface IPublicModelNodeChildren<
+  Node = IPublicModelNode
+> {
 
   /**
    * 返回当前 children 实例所属的节点实例
    * get owner node of this nodeChildren
    */
-  get owner(): IPublicModelNode | null;
+  get owner(): Node | null;
 
   /**
    * children 内的节点实例数
@@ -45,7 +47,7 @@ export interface IPublicModelNodeChildren {
    * delete the node
    * @param node
    */
-  delete(node: IPublicModelNode): boolean;
+  delete(node: Node): boolean;
 
   /**
    * 插入一个节点
@@ -54,7 +56,7 @@ export interface IPublicModelNodeChildren {
    * @param at 插入下标
    * @returns
    */
-  insert(node: IPublicModelNode, at?: number | null): void;
+  insert(node: Node, at?: number | null): void;
 
   /**
    * 返回指定节点的下标
@@ -62,7 +64,7 @@ export interface IPublicModelNodeChildren {
    * @param node
    * @returns
    */
-  indexOf(node: IPublicModelNode): number;
+  indexOf(node: Node): number;
 
   /**
    * 类似数组 splice 操作
@@ -71,7 +73,7 @@ export interface IPublicModelNodeChildren {
    * @param deleteCount
    * @param node
    */
-  splice(start: number, deleteCount: number, node?: IPublicModelNode): any;
+  splice(start: number, deleteCount: number, node?: Node): any;
 
   /**
    * 返回指定下标的节点
@@ -79,7 +81,7 @@ export interface IPublicModelNodeChildren {
    * @param index
    * @returns
    */
-  get(index: number): IPublicModelNode | null;
+  get(index: number): Node | null;
 
   /**
    * 是否包含指定节点
@@ -87,62 +89,62 @@ export interface IPublicModelNodeChildren {
    * @param node
    * @returns
    */
-  has(node: IPublicModelNode): boolean;
+  has(node: Node): boolean;
 
   /**
    * 类似数组的 forEach
    * provide the same function with {Array.prototype.forEach}
    * @param fn
    */
-  forEach(fn: (node: IPublicModelNode, index: number) => void): void;
+  forEach(fn: (node: Node, index: number) => void): void;
 
   /**
    * 类似数组的 reverse
    * provide the same function with {Array.prototype.reverse}
    */
-  reverse(): IPublicModelNode[];
+  reverse(): Node[];
 
   /**
    * 类似数组的 map
    * provide the same function with {Array.prototype.map}
    * @param fn
    */
-  map<T>(fn: (node: IPublicModelNode, index: number) => T[]): any[] | null;
+  map<T = any>(fn: (node: Node, index: number) => T): T[] | null;
 
   /**
    * 类似数组的 every
    * provide the same function with {Array.prototype.every}
    * @param fn
    */
-  every(fn: (node: IPublicModelNode, index: number) => boolean): boolean;
+  every(fn: (node: Node, index: number) => boolean): boolean;
 
   /**
    * 类似数组的 some
    * provide the same function with {Array.prototype.some}
    * @param fn
    */
-  some(fn: (node: IPublicModelNode, index: number) => boolean): boolean;
+  some(fn: (node: Node, index: number) => boolean): boolean;
 
   /**
    * 类似数组的 filter
    * provide the same function with {Array.prototype.filter}
    * @param fn
    */
-  filter(fn: (node: IPublicModelNode, index: number) => boolean): any;
+  filter(fn: (node: Node, index: number) => boolean): any;
 
   /**
    * 类似数组的 find
    * provide the same function with {Array.prototype.find}
    * @param fn
    */
-  find(fn: (node: IPublicModelNode, index: number) => boolean): IPublicModelNode | null;
+  find(fn: (node: Node, index: number) => boolean): Node | null | undefined;
 
   /**
    * 类似数组的 reduce
    * provide the same function with {Array.prototype.reduce}
    * @param fn
    */
-  reduce(fn: (acc: any, cur: IPublicModelNode) => any, initialValue: any): void;
+  reduce(fn: (acc: any, cur: Node) => any, initialValue: any): void;
 
   /**
    * 导入 schema
@@ -166,9 +168,9 @@ export interface IPublicModelNodeChildren {
    * @param sorter
    */
   mergeChildren(
-    remover: (node: IPublicModelNode, idx: number) => boolean,
-    adder: (children: IPublicModelNode[]) => IPublicTypeNodeData[] | null,
-    sorter: (firstNode: IPublicModelNode, secondNode: IPublicModelNode) => number
+    remover: (node: Node, idx: number) => boolean,
+    adder: (children: Node[]) => IPublicTypeNodeData[] | null,
+    sorter: (firstNode: Node, secondNode: Node) => number
   ): any;
 
 }

--- a/packages/types/src/shell/model/node-children.ts
+++ b/packages/types/src/shell/model/node-children.ts
@@ -97,6 +97,12 @@ export interface IPublicModelNodeChildren {
   forEach(fn: (node: IPublicModelNode, index: number) => void): void;
 
   /**
+   * 类似数组的 reverse
+   * provide the same function with {Array.prototype.reverse}
+   */
+  reverse(): IPublicModelNode[];
+
+  /**
    * 类似数组的 map
    * provide the same function with {Array.prototype.map}
    * @param fn

--- a/packages/types/src/shell/model/node.ts
+++ b/packages/types/src/shell/model/node.ts
@@ -3,7 +3,13 @@ import { IPublicTypeNodeSchema, IPublicTypeIconType, IPublicTypeI18nData, IPubli
 import { IPublicEnumTransformStage } from '../enum';
 import { IPublicModelNodeChildren, IPublicModelComponentMeta, IPublicModelProp, IPublicModelProps, IPublicModelSettingTopEntry, IPublicModelDocumentModel, IPublicModelExclusiveGroup } from './';
 
-export interface IPublicModelNode {
+export interface IBaseModelNode<
+  Document = IPublicModelDocumentModel,
+  Node = IPublicModelNode,
+  NodeChildren = IPublicModelNodeChildren,
+  ComponentMeta = IPublicModelComponentMeta,
+  SettingTopEntry = IPublicModelSettingTopEntry
+> {
 
   /**
    * 节点 id
@@ -185,43 +191,43 @@ export interface IPublicModelNode {
    * 节点的物料元数据
    * get component meta of this node
    */
-  get componentMeta(): IPublicModelComponentMeta | null;
+  get componentMeta(): ComponentMeta | null;
 
   /**
    * 获取节点所属的文档模型对象
    * get documentModel of this node
    */
-  get document(): IPublicModelDocumentModel | null;
+  get document(): Document | null;
 
   /**
    * 获取当前节点的前一个兄弟节点
    * get previous sibling of this node
    */
-  get prevSibling(): IPublicModelNode | null;
+  get prevSibling(): Node | null;
 
   /**
    * 获取当前节点的后一个兄弟节点
    * get next sibling of this node
    */
-  get nextSibling(): IPublicModelNode | null;
+  get nextSibling(): Node | null;
 
   /**
    * 获取当前节点的父亲节点
    * get parent of this node
    */
-  get parent(): IPublicModelNode | null;
+  get parent(): Node | null;
 
   /**
    * 获取当前节点的孩子节点模型
    * get children of this node
    */
-  get children(): IPublicModelNodeChildren | null;
+  get children(): NodeChildren | null;
 
   /**
    * 节点上挂载的插槽节点们
    * get slots of this node
    */
-  get slots(): IPublicModelNode[];
+  get slots(): Node[];
 
   /**
    * 当前节点为插槽节点时，返回节点对应的属性实例
@@ -258,7 +264,7 @@ export interface IPublicModelNode {
    * get setting entry of this node
    * @since v1.1.0
    */
-  get settingEntry(): IPublicModelSettingTopEntry;
+  get settingEntry(): SettingTopEntry;
 
   /**
    * 返回节点的尺寸、位置信息
@@ -359,8 +365,8 @@ export interface IPublicModelNode {
    * @param useMutator
    */
   insertBefore(
-      node: IPublicModelNode,
-      ref?: IPublicModelNode | undefined,
+      node: Node,
+      ref?: Node | undefined,
       useMutator?: boolean,
     ): void;
 
@@ -372,8 +378,8 @@ export interface IPublicModelNode {
    * @param useMutator
    */
   insertAfter(
-      node: IPublicModelNode,
-      ref?: IPublicModelNode | undefined,
+      node: Node,
+      ref?: Node | undefined,
       useMutator?: boolean,
     ): void;
 
@@ -384,7 +390,7 @@ export interface IPublicModelNode {
    * @param data 用作替换的节点对象或者节点描述
    * @returns
    */
-  replaceChild(node: IPublicModelNode, data: any): IPublicModelNode | null;
+  replaceChild(node: Node, data: any): Node | null;
 
   /**
    * 将当前节点替换成指定节点描述
@@ -427,9 +433,9 @@ export interface IPublicModelNode {
    * @since v1.1.0
    */
   mergeChildren(
-    remover: (node: IPublicModelNode, idx: number) => boolean,
-    adder: (children: IPublicModelNode[]) => any,
-    sorter: (firstNode: IPublicModelNode, secondNode: IPublicModelNode) => number
+    remover: (node: Node, idx: number) => boolean,
+    adder: (children: Node[]) => any,
+    sorter: (firstNode: Node, secondNode: Node) => number
   ): any;
 
   /**
@@ -438,7 +444,7 @@ export interface IPublicModelNode {
    * @param node
    * @since v1.1.0
    */
-  contains(node: IPublicModelNode): boolean;
+  contains(node: Node): boolean;
 
   /**
    * 是否可执行某 action
@@ -476,3 +482,5 @@ export interface IPublicModelNode {
    */
   setConditionalVisible(): void;
 }
+
+export interface IPublicModelNode extends IBaseModelNode<IPublicModelDocumentModel, IPublicModelNode> {}

--- a/packages/types/src/shell/model/plugin-context.ts
+++ b/packages/types/src/shell/model/plugin-context.ts
@@ -10,6 +10,7 @@ import {
   IPublicApiCanvas,
   IPluginPreferenceMananger,
   IPublicApiPlugins,
+  IPublicApiWorkspace,
 } from '../api';
 import { IPublicModelEngineConfig } from './';
 
@@ -28,31 +29,88 @@ export interface IPublicModelPluginContext {
    * by using this, init options can be accessed from inside plugin
    */
   preference: IPluginPreferenceMananger;
+
+  /**
+   * skeleton API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/skeleton
+   */
   get skeleton(): IPublicApiSkeleton;
+
+  /**
+   * hotkey API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/hotkey
+   */
   get hotkey(): IPublicApiHotkey;
+
+  /**
+   * setter API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/setters
+   */
   get setters(): IPublicApiSetters;
+
+  /**
+   * config API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/config
+   */
   get config(): IPublicModelEngineConfig;
+
+  /**
+   * material API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/material
+   */
   get material(): IPublicApiMaterial;
 
   /**
+   * event API
    * this event works globally, can be used between plugins and engine.
+   * @tutorial https://lowcode-engine.cn/site/docs/api/event
    */
   get event(): IPublicApiEvent;
+
+  /**
+   * project API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/project
+   */
   get project(): IPublicApiProject;
+
+  /**
+   * common API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/common
+   */
   get common(): IPublicApiCommon;
+
+  /**
+   * plugins API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/plugins
+   */
   get plugins(): IPublicApiPlugins;
+
+  /**
+   * logger API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/logger
+   */
   get logger(): IPublicApiLogger;
 
   /**
    * this event works within current plugin, on an emit locally.
+   * @tutorial https://lowcode-engine.cn/site/docs/api/event
    */
   get pluginEvent(): IPublicApiEvent;
+
+  /**
+   * canvas API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/canvas
+   */
   get canvas(): IPublicApiCanvas;
+
+  /**
+   * workspace API
+   * @tutorial https://lowcode-engine.cn/site/docs/api/workspace
+   */
+  get workspace(): IPublicApiWorkspace;
 }
 
 /**
- *
- *
  * @deprecated please use IPublicModelPluginContext instead
  */
 export interface ILowCodePluginContext extends IPublicModelPluginContext {

--- a/packages/types/src/shell/model/props.ts
+++ b/packages/types/src/shell/model/props.ts
@@ -1,7 +1,9 @@
 import { IPublicTypeCompositeValue } from '../type';
-import { IPublicModelNode, IPublicModelProp } from './';
+import { IPublicModelNode } from './';
 
-export interface IPublicModelProps {
+export interface IBaseModelProps<
+  Prop
+> {
 
   /**
    * id
@@ -24,7 +26,7 @@ export interface IPublicModelProps {
    * get prop by path
    * @param path 属性路径，支持 a / a.b / a.0 等格式
    */
-  getProp(path: string): IPublicModelProp | null;
+  getProp(path: string): Prop | null;
 
   /**
    * 获取指定 path 的属性模型实例值
@@ -39,7 +41,7 @@ export interface IPublicModelProps {
    * get extra prop by path
    * @param path 属性路径，支持 a / a.b / a.0 等格式
    */
-  getExtraProp(path: string): IPublicModelProp | null;
+  getExtraProp(path: string): Prop | null;
 
   /**
    * 获取指定 path 的属性模型实例值
@@ -83,3 +85,5 @@ export interface IPublicModelProps {
   add(value: IPublicTypeCompositeValue, key?: string | number | undefined): any;
 
 }
+
+export type IPublicModelProps = IBaseModelProps<IPublicModelProps>;

--- a/packages/types/src/shell/model/selection.ts
+++ b/packages/types/src/shell/model/selection.ts
@@ -1,7 +1,9 @@
 import { IPublicModelNode } from './';
 import { IPublicTypeDisposable } from '../type';
 
-export interface IPublicModelSelection {
+export interface IPublicModelSelection<
+  Node = IPublicModelNode
+> {
 
   /**
    * 返回选中的节点 id
@@ -14,7 +16,7 @@ export interface IPublicModelSelection {
    * return selected Node instance，return the first one if multiple nodes are selected
    * @since v1.1.0
    */
-  get node(): IPublicModelNode | null;
+  get node(): Node | null;
 
   /**
    * 选中指定节点（覆盖方式）
@@ -62,7 +64,7 @@ export interface IPublicModelSelection {
    * 获取选中的节点实例
    * get selected nodes
    */
-  getNodes(): IPublicModelNode[];
+  getNodes(): Node[];
 
   /**
    * 获取选区的顶层节点
@@ -72,7 +74,7 @@ export interface IPublicModelSelection {
    *  getTopNodes() will return [A, B], subA will be removed
    * @since v1.0.16
    */
-  getTopNodes(includeRoot?: boolean): IPublicModelNode[];
+  getTopNodes(includeRoot?: boolean): Node[];
 
   /**
    * 注册 selection 变化事件回调

--- a/packages/types/src/shell/type/drag-node-object.ts
+++ b/packages/types/src/shell/type/drag-node-object.ts
@@ -1,7 +1,7 @@
 import { IPublicModelNode } from '..';
 import { IPublicEnumDragObjectType } from '../enum';
 
-export interface IPublicTypeDragNodeObject {
+export interface IPublicTypeDragNodeObject<Node = IPublicModelNode> {
   type: IPublicEnumDragObjectType.Node;
-  nodes: IPublicModelNode[];
+  nodes: Node[];
 }

--- a/packages/types/src/shell/type/field-config.ts
+++ b/packages/types/src/shell/type/field-config.ts
@@ -13,7 +13,7 @@ export interface IPublicTypeFieldConfig extends IPublicTypeFieldExtraProps {
   /**
    * the name of this setting field, which used in quickEditor
    */
-  name: string | number;
+  name?: string | number;
 
   /**
    * the field title

--- a/packages/types/src/shell/type/field-extra-props.ts
+++ b/packages/types/src/shell/type/field-extra-props.ts
@@ -19,12 +19,12 @@ export interface IPublicTypeFieldExtraProps {
   /**
    * get value for field
    */
-  getValue?: (target: IPublicModelSettingTarget, fieldValue: any) => any;
+  getValue?: (target: IPublicModelSettingPropEntry, fieldValue: any) => any;
 
   /**
    * set value for field
    */
-  setValue?: (target: IPublicModelSettingTarget, value: any) => void;
+  setValue?: (target: IPublicModelSettingPropEntry, value: any) => void;
 
   /**
    * the field conditional show, is not set always true

--- a/packages/types/src/shell/type/field-extra-props.ts
+++ b/packages/types/src/shell/type/field-extra-props.ts
@@ -1,59 +1,72 @@
-import { IPublicModelSettingTarget } from '../model';
+import { IPublicModelSettingPropEntry, IPublicModelSettingTarget } from '../model';
 import { IPublicTypeLiveTextEditingConfig } from './';
 
 /**
  * extra props for field
  */
 export interface IPublicTypeFieldExtraProps {
+
   /**
    * 是否必填参数
    */
   isRequired?: boolean;
+
   /**
    * default value of target prop for setter use
    */
   defaultValue?: any;
+
   /**
    * get value for field
    */
   getValue?: (target: IPublicModelSettingTarget, fieldValue: any) => any;
+
   /**
    * set value for field
    */
   setValue?: (target: IPublicModelSettingTarget, value: any) => void;
+
   /**
    * the field conditional show, is not set always true
    * @default undefined
    */
-  condition?: (target: IPublicModelSettingTarget) => boolean;
+  condition?: (target: IPublicModelSettingPropEntry) => boolean;
+
   /**
    * autorun when something change
    */
   autorun?: (target: IPublicModelSettingTarget) => void;
+
   /**
    * is this field is a virtual field that not save to schema
    */
   virtual?: (target: IPublicModelSettingTarget) => boolean;
+
   /**
    * default collapsed when display accordion
    */
   defaultCollapsed?: boolean;
+
   /**
    * important field
    */
   important?: boolean;
+
   /**
    * internal use
    */
   forceInline?: number;
+
   /**
    * 是否支持变量配置
    */
   supportVariable?: boolean;
+
   /**
    * compatiable vision display
    */
   display?: 'accordion' | 'inline' | 'block' | 'plain' | 'popup' | 'entry';
+
   // @todo 这个 omit 是否合理？
   /**
    * @todo 待补充文档

--- a/packages/types/src/shell/type/metadata.ts
+++ b/packages/types/src/shell/type/metadata.ts
@@ -1,5 +1,5 @@
 import { IPublicTypePropType, IPublicTypeComponentAction } from './';
-import { IPublicModelProp, IPublicModelSettingTarget } from '../model';
+import { IPublicModelNode, IPublicModelProp, IPublicModelSettingTarget } from '../model';
 
 /**
  * 嵌套控制函数
@@ -184,20 +184,20 @@ export interface ConfigureSupport {
  */
 export interface IPublicTypeCallbacks {
   // hooks
-  onMouseDownHook?: (e: MouseEvent, currentNode: any) => any;
-  onDblClickHook?: (e: MouseEvent, currentNode: any) => any;
-  onClickHook?: (e: MouseEvent, currentNode: any) => any;
+  onMouseDownHook?: (e: MouseEvent, currentNode: IPublicModelNode) => any;
+  onDblClickHook?: (e: MouseEvent, currentNode: IPublicModelNode) => any;
+  onClickHook?: (e: MouseEvent, currentNode: IPublicModelNode) => any;
   // onLocateHook?: (e: any, currentNode: any) => any;
   // onAcceptHook?: (currentNode: any, locationData: any) => any;
-  onMoveHook?: (currentNode: any) => boolean;
+  onMoveHook?: (currentNode: IPublicModelNode) => boolean;
   // thinkof 限制性拖拽
-  onHoverHook?: (currentNode: any) => boolean;
-  onChildMoveHook?: (childNode: any, currentNode: any) => boolean;
+  onHoverHook?: (currentNode: IPublicModelNode) => boolean;
+  onChildMoveHook?: (childNode: IPublicModelNode, currentNode: IPublicModelNode) => boolean;
 
   // events
-  onNodeRemove?: (removedNode: any, currentNode: any) => void;
-  onNodeAdd?: (addedNode: any, currentNode: any) => void;
-  onSubtreeModified?: (currentNode: any, options: any) => void;
+  onNodeRemove?: (removedNode: IPublicModelNode, currentNode: IPublicModelNode) => void;
+  onNodeAdd?: (addedNode: IPublicModelNode, currentNode: IPublicModelNode) => void;
+  onSubtreeModified?: (currentNode: IPublicModelNode, options: any) => void;
   onResize?: (
     e: MouseEvent & {
       trigger: string;
@@ -220,6 +220,6 @@ export interface IPublicTypeCallbacks {
       deltaX?: number;
       deltaY?: number;
     },
-    currentNode: any,
+    currentNode: IPublicModelNode,
   ) => void;
 }

--- a/packages/types/src/shell/type/setter-config.ts
+++ b/packages/types/src/shell/type/setter-config.ts
@@ -6,49 +6,60 @@ import { IPublicTypeDynamicProps } from './dynamic-props';
  * 设置器配置
  */
 export interface IPublicTypeSetterConfig {
+
   // if *string* passed must be a registered Setter Name
   /**
    * 配置设置器用哪一个 setter
    */
   componentName: string | IPublicTypeCustomView;
+
   /**
    * 传递给 setter 的属性
    *
    * the props pass to Setter Component
    */
   props?: Record<string, unknown> | IPublicTypeDynamicProps;
+
   /**
    * @deprecated
    */
   children?: any;
+
   /**
    * 是否必填？
    *
    * ArraySetter 里有个快捷预览，可以在不打开面板的情况下直接编辑
    */
   isRequired?: boolean;
+
   /**
    * Setter 的初始值
    *
    * @todo initialValue 可能要和 defaultValue 二选一
    */
   initialValue?: any | ((target: IPublicModelSettingTarget) => any);
+
+  defaultValue?: any;
+
   // for MixedSetter
   /**
    * 给 MixedSetter 时切换 Setter 展示用的
    */
   title?: IPublicTypeTitleContent;
+
   // for MixedSetter check this is available
   /**
    * 给 MixedSetter 用于判断优先选中哪个
    */
   condition?: (target: IPublicModelSettingTarget) => boolean;
+
   /**
    * 给 MixedSetter，切换值时声明类型
    *
    * @todo 物料协议推进
    */
   valueType?: IPublicTypeCompositeValue[];
+
   // 标识是否为动态 setter，默认为 true
   isDynamic?: boolean;
 }

--- a/packages/utils/src/check-types/is-drag-node-data-object.ts
+++ b/packages/utils/src/check-types/is-drag-node-data-object.ts
@@ -1,5 +1,5 @@
-import { IPublicEnumDragObjectType } from '@alilc/lowcode-types';
+import { IPublicEnumDragObjectType, IPublicTypeDragNodeDataObject } from '@alilc/lowcode-types';
 
-export function isDragNodeDataObject(obj: any): boolean {
+export function isDragNodeDataObject(obj: any): obj is IPublicTypeDragNodeDataObject {
   return obj && obj.type === IPublicEnumDragObjectType.NodeData;
 }

--- a/packages/utils/src/check-types/is-drag-node-object.ts
+++ b/packages/utils/src/check-types/is-drag-node-object.ts
@@ -1,5 +1,5 @@
-import { IPublicEnumDragObjectType } from '@alilc/lowcode-types';
+import { IPublicEnumDragObjectType, IPublicModelNode, IPublicTypeDragNodeObject } from '@alilc/lowcode-types';
 
-export function isDragNodeObject(obj: any): boolean {
+export function isDragNodeObject<Node = IPublicModelNode>(obj: any): obj is IPublicTypeDragNodeObject<Node> {
   return obj && obj.type === IPublicEnumDragObjectType.Node;
 }

--- a/packages/utils/src/check-types/is-node.ts
+++ b/packages/utils/src/check-types/is-node.ts
@@ -1,3 +1,5 @@
-export function isNode(node: any): boolean {
+import { IPublicModelNode } from '@alilc/lowcode-types';
+
+export function isNode<Node = IPublicModelNode>(node: any): node is Node {
   return node && node.isNode;
 }

--- a/packages/utils/test/src/build-components/buildComponents.test.ts
+++ b/packages/utils/test/src/build-components/buildComponents.test.ts
@@ -1,0 +1,336 @@
+
+import { buildComponents } from "../../../src/build-components";
+
+function Button() {};
+
+function WrapButton() {};
+
+function ButtonGroup() {};
+
+function WrapButtonGroup() {};
+
+ButtonGroup.Button = Button;
+
+Button.displayName = "Button";
+ButtonGroup.displayName = "ButtonGroup";
+ButtonGroup.prototype.isReactComponent = true;
+Button.prototype.isReactComponent = true;
+
+jest.mock('../../../src/is-react', () => {
+  const original = jest.requireActual('../../../src/is-react');
+  return {
+    ...original,
+    wrapReactClass(view) {
+      return view;
+    }
+  }
+})
+
+describe('build-component', () => {
+  it('basic button', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': {
+            Button,
+          }
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'Button',
+            subName: 'Button',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+    });
+  });
+
+  it('component is a  __esModule', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': {
+            __esModule: true,
+            default: Button,
+          }
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+    });
+  })
+
+  it('basic warp button', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': {
+            WrapButton,
+          }
+        },
+        {
+          WrapButton: {
+            componentName: 'WrapButton',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'WrapButton',
+            subName: 'WrapButton',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      WrapButton,
+    });
+  });
+
+  it('destructuring is false button', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': Button
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+            destructuring: false,
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+    });
+  });
+
+  it('Button and ButtonGroup', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': {
+            Button,
+            ButtonGroup,
+          }
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'Button',
+            subName: 'Button',
+          },
+          ButtonGroup: {
+            componentName: 'ButtonGroup',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'ButtonGroup',
+            subName: 'ButtonGroup',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+      ButtonGroup,
+    });
+  });
+
+  it('ButtonGroup and ButtonGroup.Button', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': {
+            ButtonGroup,
+          }
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'ButtonGroup',
+            subName: 'ButtonGroup.Button',
+          },
+          ButtonGroup: {
+            componentName: 'ButtonGroup',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'ButtonGroup',
+            subName: 'ButtonGroup',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+      ButtonGroup,
+    });
+  });
+
+  it('ButtonGroup.default and ButtonGroup.Button', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': ButtonGroup,
+        },
+        {
+          Button: {
+            componentName: 'Button',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'Button',
+            subName: 'Button',
+          },
+          ButtonGroup: {
+            componentName: 'ButtonGroup',
+            package: '@alilc/button',
+            destructuring: true,
+            exportName: 'default',
+            subName: 'default',
+          }
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+      ButtonGroup,
+    });
+  });
+
+  it('no npm component', () => {
+    expect(
+      buildComponents(
+        {
+          '@alilc/button': Button,
+        },
+        {
+          Button: null,
+        },
+        () => {},
+      ))
+    .toEqual({});
+  });
+
+  it('no npm component and global button', () => {
+    window.Button = Button;
+    expect(
+      buildComponents(
+        {},
+        {
+          Button: null,
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+    });
+    window.Button = null;
+  });
+
+  it('componentsMap value is component funtion', () => {
+    expect(
+      buildComponents(
+        {},
+        {
+          Button,
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button,
+    });
+  });
+
+
+  it('componentsMap value is component', () => {
+    expect(
+      buildComponents(
+        {},
+        {
+          Button: WrapButton,
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button: WrapButton,
+    });
+  });
+
+  it('componentsMap value is mix component', () => {
+    expect(
+      buildComponents(
+        {},
+        {
+          Button: {
+            WrapButton,
+            Button,
+            ButtonGroup,
+          },
+        },
+        () => {},
+      ))
+    .toEqual({
+      Button: {
+        WrapButton,
+        Button,
+        ButtonGroup,
+      },
+    });
+  });
+
+  it('componentsMap value is Lowcode Component', () => {
+    expect(
+      buildComponents(
+        {},
+        {
+          Button: {
+            componentName: 'Component',
+            schema: {},
+          },
+        },
+        (component) => {
+          return component as any;
+        },
+      ))
+    .toEqual({
+      Button: {
+        componentName: 'Component',
+        schema: {},
+      },
+    });
+  })
+});
+
+describe('build div component', () => {
+  it('build div component', () => {
+    const components = buildComponents(
+      {
+        '@alilc/div': 'div'
+      },
+      {
+        div: {
+          componentName: 'div',
+          package: '@alilc/div'
+        }
+      },
+      () => {},
+    );
+
+    expect(components['div']).not.toBeNull();
+  })
+})

--- a/packages/utils/test/src/build-components/getProjectUtils.test.ts
+++ b/packages/utils/test/src/build-components/getProjectUtils.test.ts
@@ -1,0 +1,43 @@
+import { getProjectUtils } from "../../../src/build-components";
+
+const sampleUtil = () => 'I am a sample util';
+const sampleUtil2 = () => 'I am a sample util 2';
+
+describe('get project utils', () => {
+  it('get utils with destructuring true', () => {
+    expect(getProjectUtils(
+      {
+        '@alilc/utils': {
+          destructuring: true,
+          sampleUtil,
+          sampleUtil2,
+        }
+      },
+      [{
+        name: 'sampleUtils',
+        npm: {
+          package: '@alilc/utils'
+        }
+      }]
+    )).toEqual({
+      sampleUtil,
+      sampleUtil2,
+    })
+  });
+
+  it('get utils with name', () => {
+    expect(getProjectUtils(
+      {
+        '@alilc/utils': sampleUtil
+      },
+      [{
+        name: 'sampleUtil',
+        npm: {
+          package: '@alilc/utils'
+        }
+      }]
+    )).toEqual({
+      sampleUtil,
+    })
+  });
+})

--- a/packages/utils/test/src/build-components/getSubComponent.test.ts
+++ b/packages/utils/test/src/build-components/getSubComponent.test.ts
@@ -1,0 +1,85 @@
+import { getSubComponent } from '../../../src/build-components';
+
+function Button() {}
+
+function ButtonGroup() {}
+
+ButtonGroup.Button = Button;
+
+function OnlyButtonGroup() {}
+
+describe('getSubComponent library is object', () => {
+  it('get Button from Button', () => {
+    expect(getSubComponent({
+      Button,
+    }, ['Button'])).toBe(Button);
+  });
+
+  it('get ButtonGroup.Button from ButtonGroup', () => {
+    expect(getSubComponent({
+      ButtonGroup,
+    }, ['ButtonGroup', 'Button'])).toBe(Button);
+  });
+
+  it('get ButtonGroup from ButtonGroup', () => {
+    expect(getSubComponent({
+      ButtonGroup,
+    }, ['ButtonGroup'])).toBe(ButtonGroup);
+  });
+
+  it('get ButtonGroup.Button from OnlyButtonGroup', () => {
+    expect(getSubComponent({
+      ButtonGroup: OnlyButtonGroup,
+    }, ['ButtonGroup', 'Button'])).toBe(OnlyButtonGroup);
+  });
+});
+
+describe('getSubComponent library is null', () => {
+  it('getSubComponent library is null', () => {
+    expect(getSubComponent(null, ['ButtonGroup', 'Button'])).toBeNull();
+  });
+})
+
+describe('getSubComponent paths is []', () => {
+  it('getSubComponent paths is []', () => {
+    expect(getSubComponent(Button, [])).toBe(Button);
+  });
+});
+
+describe('getSubComponent make error', () => {
+  it('library is string', () => {
+    expect(getSubComponent(true, ['Button'])).toBe(null);
+  });
+
+  it('library is boolean', () => {
+    expect(getSubComponent('I am a string', ['Button'])).toBe(null);
+  });
+
+  it('library is number', () => {
+    expect(getSubComponent(123, ['Button'])).toBe(null);
+  });
+
+  it('library ButtonGroup is null', () => {
+    expect(getSubComponent({
+      ButtonGroup: null,
+    }, ['ButtonGroup', 'Button'])).toBe(null);
+  });
+
+  it('library ButtonGroup.Button is null', () => {
+    expect(getSubComponent({
+      ButtonGroup: null,
+    }, ['ButtonGroup', 'Button', 'SubButton'])).toBe(null);
+  });
+
+  it('path  s is [[]]', () => {
+    expect(getSubComponent({
+      ButtonGroup: null,
+    }, [['ButtonGroup'] as any, 'Button'])).toBe(null);
+  });
+
+  it('ButtonGroup is undefined', () => {
+    expect(getSubComponent({
+      ButtonGroup: undefined,
+    }, ['ButtonGroup', 'Button'])).toBe(null);
+  });
+})


### PR DESCRIPTION
VC组件通过prototype中的canResizing函数来配置组件某一边是否可拖拽,并在componentDidMount绑定resize事件,但由于单边的div元素采用了动态渲染,当canResizing发生变化时div会销毁然后重新挂载,但是挂载后并没有重新绑定拖拽事件,导致无法重新拖拽,将动态渲染修改为通过style控制显示隐藏即可

```jsx
  componentDidMount() {
    this.willBind();
  }
  render() {
    // 动态渲染
    return (
      <div>
        {triggerVisible.includes("N") && (
          <div
            ref={(ref) => {
              this.outlineN = ref;
            }}
            className={classNames(baseSideClass, "n")}
            style={{
              height: 20,
              transform: `translate(${offsetLeft}px, ${offsetTop - 10}px)`,
              width: offsetWidth,
            }}
          />
        )}
      </div>
    );
  }
```
