### PR TITLE
Update node-helper.ts

### DIFF
--- a/packages/utils/src/node-helper.ts
+++ b/packages/utils/src/node-helper.ts
@@ -23,7 +23,7 @@ export const getClosestNode = (
  * @returns {boolean} 是否可点击，true表示可点击
  */
 export const canClickNode = (node: IPublicModelNode, e: unknown): boolean => {
-  const onClickHook = node.componentMeta?.advanced.callbacks?.onClickHook;
+  const onClickHook = node.componentMeta?.advanced?.callbacks?.onClickHook;
   const canClick = typeof onClickHook === 'function' ? onClickHook(e as MouseEvent, node) : true;
   return canClick;
 };


### PR DESCRIPTION
缺少容错，我们再禁用高级属性的时候，会导致大纲树在选择组件无法被选中，提示未找到callbacks，（旧版本是有这个容错的）