### PR TITLE
修复属性类型为object设置器为boolsetter被异常重置的bug

### DIFF
--- a/packages/editor-skeleton/src/components/settings/settings-pane.tsx
+++ b/packages/editor-skeleton/src/components/settings/settings-pane.tsx
@@ -170,6 +170,7 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
     const { initialValue } = this.setterInfo;
     if (this.state?.fromOnChange ||
       !isInitialValueNotEmpty(initialValue) ||
+      !this.visible ||
       this.value !== undefined
     ) {
       return;


### PR DESCRIPTION
修复https://github.com/alibaba/lowcode-engine/issues/1599%EF%BC%8C
优化之前的提交，只需要在初始化默认值的时候，增加设置器是否显示的判断逻辑即可兼容 issue中提到的兼容性问题