### PR TITLE
docs: 事件api文档中emit使用了off的接口

### DIFF
--- a/docs/docs/api/event.md
+++ b/docs/docs/api/event.md
@@ -44,7 +44,7 @@ off(event: string, listener: (...args: any[]) => void): void;
 ```typescript
 /**
  * 触发事件
- * emit a message fot a event
+ * emit a message for a event
  * @param event 事件名称
  * @param args 事件参数
  * @returns

--- a/docs/docs/api/event.md
+++ b/docs/docs/api/event.md
@@ -43,12 +43,13 @@ off(event: string, listener: (...args: any[]) => void): void;
 
 ```typescript
 /**
- * 取消监听事件
- * cancel a monitor from a event
+ * 触发事件
+ * emit a message fot a event
  * @param event 事件名称
- * @param listener 事件回调
+ * @param args 事件参数
+ * @returns
  */
-off(event: string, listener: (...args: any[]) => void): void;
+emit(event: string, ...args: any[]): void;
 ```
 
 ## 使用示例

--- a/packages/types/src/shell/api/event.ts
+++ b/packages/types/src/shell/api/event.ts
@@ -21,7 +21,7 @@ export interface IPublicApiEvent {
 
   /**
    * 触发事件
-   * emit a message fot a event
+   * emit a message for a event
    * @param event 事件名称
    * @param args 事件参数
    * @returns


### PR DESCRIPTION
事件`api`中`emit`错误的使用了`off`接口