### PR TITLE
feat: material spec add ignoreDefaultValue field to component property description

### DIFF
--- a/docs/docs/specs/material-spec.md
+++ b/docs/docs/specs/material-spec.md
@@ -834,6 +834,7 @@ props 数组下对象字段描述：
 | defaultValue | 默认值 | Any(视字段类型而定) | type = 'field' 生效 |
 | supportVariable | 是否支持配置变量 | Boolean | type = 'field' 生效 |
 | condition | 配置当前 prop 是否展示 | (target: IPublicModelSettingField) => boolean; | - |
+| ignoreDefaultValue | 配置当前 prop 是否忽略默认值处理逻辑，如果返回值是 true 引擎不会处理默认值 | (target: IPublicModelSettingField) => boolean; | - |
 | setter     | 单个控件 (setter) 描述，搭建基础协议组件的描述对象，支持 JSExpression / JSFunction / JSSlot | `String\|Object\|Function` | type = 'field' 生效 |
 | extraProps | 其他配置属性（不做流通要求）                                                           | Object            | 其他配置            |
 | extraProps.getValue | setter 渲染时被调用，setter 会根据该函数的返回值设置 setter 当前值 | Function            | (target: IPublicModelSettingField, value: any) => any;            |

--- a/packages/editor-skeleton/src/components/settings/settings-pane.tsx
+++ b/packages/editor-skeleton/src/components/settings/settings-pane.tsx
@@ -88,6 +88,18 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
     return true;
   }
 
+  get ignoreDefaultValue(): boolean {
+    const { extraProps } = this.field;
+    const { ignoreDefaultValue } = extraProps;
+    try {
+      return typeof ignoreDefaultValue === 'function' ? ignoreDefaultValue(this.field.internalToShell()) : false;
+    } catch (error) {
+      console.error('exception when ignoreDefaultValue is excuted', error);
+    }
+
+    return false;
+  }
+
   get setterInfo(): {
     setterProps: any;
     initialValue: any;
@@ -171,6 +183,7 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
     const { initialValue } = this.setterInfo;
     if (this.state?.fromOnChange ||
       !isInitialValueNotEmpty(initialValue) ||
+      this.ignoreDefaultValue ||
       this.value !== undefined
     ) {
       return;

--- a/packages/types/src/shell/type/field-extra-props.ts
+++ b/packages/types/src/shell/type/field-extra-props.ts
@@ -33,6 +33,12 @@ export interface IPublicTypeFieldExtraProps {
   condition?: (target: IPublicModelSettingField) => boolean;
 
   /**
+   * 配置当前 prop 是否忽略默认值处理逻辑，如果返回值是 true 引擎不会处理默认值
+   * @returns boolean
+   */
+  ignoreDefaultValue?: (target: IPublicModelSettingField) => boolean;
+
+  /**
    * autorun when something change
    */
   autorun?: (target: IPublicModelSettingField) => void;


### PR DESCRIPTION
新增 ignoreDefaultValue 属性描述

![image](https://user-images.githubusercontent.com/11935995/225191916-79de6c00-fbcd-4a6a-bcc6-ac45abe41e1f.png)

用于满足复合属性的配置场景：

如下图的 AntD Table 物料描述，当 pagination 为 {} 则展示翻页，当 pagination 为 false 时则不展示翻页。而原来的物料描述中只有 condition 字段，这个字段只是控制显示隐藏与否，和设置 defaultValue 没有关系，因此需要新增 ignoreDefaultValue 来配置是否忽略 defaultValue 的字段。

![image](https://user-images.githubusercontent.com/11935995/225192386-1d8b2ed2-77b8-4565-82d7-48d7c6a27468.png)

