### PR TITLE
fix: missing i18n param in simulator and renderer

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -6,6 +6,7 @@ import {
   getPublicPath,
   focusTracker,
   engineConfig,
+  globalLocale,
   IReactionPublic,
   IReactionOptions,
   IReactionDisposer,
@@ -198,7 +199,7 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
   }
 
   @computed get locale(): string {
-    return this.get('locale');
+    return this.get('locale') || globalLocale.getLocale();
   }
 
   @computed get deviceClassName(): string | undefined {

--- a/packages/react-simulator-renderer/src/renderer.ts
+++ b/packages/react-simulator-renderer/src/renderer.ts
@@ -456,6 +456,7 @@ export class SimulatorRendererContainer implements BuiltinSimulatorRenderer {
           components: renderer.components,
           designMode: '',
           device: renderer.device,
+          locale: renderer.locale,
           appHelper: renderer.context,
           rendererName: 'LowCodeRenderer',
           thisRequiredInJSE: host.thisRequiredInJSE,


### PR DESCRIPTION
fix the missing i18n param in simulator and renderer so that display i18n of "Drag and drop components or templates here" in  simulator: https://github.com/alibaba/lowcode-engine/pull/1497/files