### PR TITLE
feat: add setConfig method for project

### DIFF
--- a/docs/docs/api/project.md
+++ b/docs/docs/api/project.md
@@ -252,6 +252,35 @@ setI18n(value: object): void;
 
 **@since v1.0.17**
 
+### setConfig
+设置当前项目配置
+
+```typescript
+/**
+ * 设置当前项目配置
+ * set config for this project
+ * @param value object
+ * @since v1.1.4
+ */
+  setConfig(value: IPublicTypeAppConfig): void;
+  setConfig<T extends keyof IPublicTypeAppConfig>(key: T, value: IPublicTypeAppConfig[T]): void;
+```
+
+**@since v1.1.4**
+
+#### 如何扩展项目配置
+
+```typescript
+// shims.d.ts
+declare module '@alilc/lowcode-types' {
+  export interface IPublicTypeAppConfig {
+    customProp: CustomPropType
+  }
+}
+
+export {};
+```
+
 
 ## 事件
 

--- a/packages/designer/src/project/project.ts
+++ b/packages/designer/src/project/project.ts
@@ -11,7 +11,7 @@ import {
 import { isLowCodeComponentType, isProCodeComponentType } from '@alilc/lowcode-utils';
 import { ISimulatorHost } from '../simulator';
 
-export interface IProject extends Omit< IBaseApiProject<
+export interface IProject extends Omit<IBaseApiProject<
   IDocumentModel
 >,
   'simulatorHost' |
@@ -26,6 +26,7 @@ export interface IProject extends Omit< IBaseApiProject<
   'onSimulatorHostReady' |
   'onSimulatorRendererReady' |
   'setI18n' |
+  'setConfig' |
   'currentDocument' |
   'selection' |
   'documents' |
@@ -72,21 +73,15 @@ export interface IProject extends Omit< IBaseApiProject<
   /**
    * 分字段设置储存数据，不记录操作记录
    */
-  set(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    key:
-      | 'version'
-      | 'componentsTree'
-      | 'componentsMap'
-      | 'utils'
-      | 'constants'
-      | 'i18n'
-      | 'css'
-      | 'dataSource'
-      | string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    value: any,
-  ): void;
+  set<T extends keyof IPublicTypeProjectSchema>(key: T, value: IPublicTypeProjectSchema[T]): void;
+  set(key: string, value: unknown): void;
+
+  /**
+   * 分字段获取储存数据
+   */
+  get<T extends keyof IPublicTypeProjectSchema>(key: T): IPublicTypeProjectSchema[T];
+  get<T>(key: string): T;
+  get(key: string): unknown;
 
   checkExclusive(activeDoc: DocumentModel): void;
 }
@@ -265,21 +260,9 @@ export class Project implements IProject {
   /**
    * 分字段设置储存数据，不记录操作记录
    */
-  set(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    key:
-      | 'version'
-      | 'componentsTree'
-      | 'componentsMap'
-      | 'utils'
-      | 'constants'
-      | 'i18n'
-      | 'css'
-      | 'dataSource'
-      | string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    value: any,
-  ): void {
+  set<T extends keyof IPublicTypeProjectSchema>(key: T, value: IPublicTypeProjectSchema[T]): void;
+  set(key: string, value: unknown): void;
+  set(key: string, value: unknown): void {
     if (key === 'config') {
       this.config = value;
     }
@@ -292,20 +275,10 @@ export class Project implements IProject {
   /**
    * 分字段设置储存数据
    */
-  get(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    key:
-      | 'version'
-      | 'componentsTree'
-      | 'componentsMap'
-      | 'utils'
-      | 'constants'
-      | 'i18n'
-      | 'css'
-      | 'dataSource'
-      | 'config'
-      | string,
-  ): any {
+  get<T extends keyof IPublicTypeRootSchema>(key: T): IPublicTypeRootSchema[T];
+  get<T>(key: string): T;
+  get(key: string): unknown;
+  get(key: string): any {
     if (key === 'config') {
       return this.config;
     }

--- a/packages/shell/src/api/project.ts
+++ b/packages/shell/src/api/project.ts
@@ -13,6 +13,7 @@ import {
   IPublicTypePropsTransducer,
   IPublicEnumTransformStage,
   IPublicTypeDisposable,
+  IPublicTypeAppConfig,
 } from '@alilc/lowcode-types';
 import { DocumentModel as ShellDocumentModel } from '../model';
 import { SimulatorHost } from './simulator-host';
@@ -215,5 +216,24 @@ export class Project implements IPublicApiProject {
    */
   setI18n(value: object): void {
     this[projectSymbol].set('i18n', value);
+  }
+
+  /**
+   * 设置项目配置
+   * @param value object
+   * @returns
+   */
+  setConfig<T extends keyof IPublicTypeAppConfig>(key: T, value: IPublicTypeAppConfig[T]): void;
+  setConfig(value: IPublicTypeAppConfig): void;
+  setConfig(...params: any[]): void{
+    if(params.length === 2) {
+      const oldConfig = this[projectSymbol].get('config');
+      this[projectSymbol].set('config', {
+        ...oldConfig,
+        [params[0]]: params[1],
+      })
+    } else {
+      this[projectSymbol].set('config', params[0])
+    }
   }
 }

--- a/packages/types/src/shell/api/project.ts
+++ b/packages/types/src/shell/api/project.ts
@@ -1,4 +1,4 @@
-import { IPublicTypeProjectSchema, IPublicTypeDisposable, IPublicTypeRootSchema, IPublicTypePropsTransducer } from '../type';
+import { IPublicTypeProjectSchema, IPublicTypeDisposable, IPublicTypeRootSchema, IPublicTypePropsTransducer, IPublicTypeAppConfig } from '../type';
 import { IPublicEnumTransformStage } from '../enum';
 import { IPublicApiSimulatorHost } from './';
 import { IPublicModelDocumentModel } from '../model';
@@ -132,6 +132,16 @@ export interface IBaseApiProject<
    * @since v1.0.17
    */
   setI18n(value: object): void;
+
+  /**
+   * 设置当前项目配置
+   *
+   * set config data for this project
+   * @param value object
+   * @since v1.1.4
+   */
+  setConfig<T extends keyof IPublicTypeAppConfig>(key: T, value: IPublicTypeAppConfig[T]): void;
+  setConfig(value: IPublicTypeAppConfig): void;
 }
 
 export interface IPublicApiProject extends IBaseApiProject<IPublicModelDocumentModel> {}

--- a/packages/types/src/shell/type/app-config.ts
+++ b/packages/types/src/shell/type/app-config.ts
@@ -4,7 +4,6 @@ export interface IPublicTypeAppConfig {
   targetRootID?: string;
   layout?: IPublicTypeLayout;
   theme?: IPublicTypeTheme;
-  [key: string]: any;
 }
 
 interface IPublicTypeTheme {

--- a/packages/types/src/shell/type/project-schema.ts
+++ b/packages/types/src/shell/type/project-schema.ts
@@ -57,8 +57,10 @@ export interface IPublicTypeProjectSchema<T = IPublicTypeRootSchema> {
   dataSource?: DataSource;
   /**
    * 当前应用配置信息
+   *
+   * TODO: 需要在后续版本中移除 `Record<string, unknown>` 类型签名
    */
-  config?: IPublicTypeAppConfig | Record<string, any>;
+  config?: IPublicTypeAppConfig & Record<string, unknown>;
   /**
    * 当前应用元数据信息
    */


### PR DESCRIPTION
添加设置项目配置的方法，可以通过 `project.setConfig('key', value)` 来这只 projectSchema 的 config 属性值