### PR TITLE
fix: ts interface error

### DIFF
--- a/packages/designer/src/designer/detecting.ts
+++ b/packages/designer/src/designer/detecting.ts
@@ -1,10 +1,10 @@
 import { makeObservable, obx, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor-core';
 import { IPublicModelDetecting } from '@alilc/lowcode-types';
-import { IDocumentModel } from '../document/document-model';
-import { INode } from '../document/node/node';
+import type { IDocumentModel } from '../document/document-model';
+import type { INode } from '../document/node/node';
 
 const DETECTING_CHANGE_EVENT = 'detectingChange';
-export interface IDetecting extends Omit< IPublicModelDetecting<INode>,
+export interface IDetecting extends Omit<IPublicModelDetecting<INode>,
   'capture' |
   'release' |
   'leave'

--- a/packages/designer/src/designer/location.ts
+++ b/packages/designer/src/designer/location.ts
@@ -1,4 +1,4 @@
-import { IDocumentModel, INode } from '../document';
+import type { IDocumentModel, INode } from '../document';
 import { ILocateEvent } from './dragon';
 import {
   IPublicModelDropLocation,
@@ -98,7 +98,7 @@ function isDocument(elem: any): elem is Document {
 export function getWindow(elem: Element | Document): Window {
   return (isDocument(elem) ? elem : elem.ownerDocument!).defaultView!;
 }
-export interface IDropLocation extends Omit< IPublicModelDropLocation, 'target' | 'clone' > {
+export interface IDropLocation extends Omit<IPublicModelDropLocation, 'target' | 'clone'> {
 
   readonly source: string;
 

--- a/packages/designer/src/designer/setting/setting-field.ts
+++ b/packages/designer/src/designer/setting/setting-field.ts
@@ -6,10 +6,12 @@ import {
   IPublicTypeFieldExtraProps,
   IPublicTypeFieldConfig,
   IPublicTypeCustomView,
-  IPublicTypeSetValueOptions,
   IPublicTypeDisposable,
   IPublicModelSettingField,
   IBaseModelSettingField,
+} from '@alilc/lowcode-types';
+import type {
+  IPublicTypeSetValueOptions,
 } from '@alilc/lowcode-types';
 import { Transducer } from './utils';
 import { ISettingPropEntry, SettingPropEntry } from './setting-prop-entry';
@@ -31,10 +33,10 @@ function getSettingFieldCollectorKey(parent: ISettingTopEntry | ISettingField, c
 }
 
 export interface ISettingField extends ISettingPropEntry, Omit<IBaseModelSettingField<
-ISettingTopEntry,
-ISettingField,
-IComponentMeta,
-INode
+  ISettingTopEntry,
+  ISettingField,
+  IComponentMeta,
+  INode
 >, 'setValue' | 'key' | 'node'> {
   get items(): Array<ISettingField | IPublicTypeCustomView>;
 

--- a/packages/designer/src/designer/setting/setting-prop-entry.ts
+++ b/packages/designer/src/designer/setting/setting-prop-entry.ts
@@ -3,7 +3,7 @@ import { GlobalEvent, IPublicApiSetters, IPublicModelEditor, IPublicModelSetting
 import { uniqueId, isJSExpression } from '@alilc/lowcode-utils';
 import { ISettingEntry } from './setting-entry-type';
 import { INode } from '../../document';
-import { IComponentMeta } from '../../component-meta';
+import type { IComponentMeta } from '../../component-meta';
 import { IDesigner } from '../designer';
 import { ISettingTopEntry } from './setting-top-entry';
 import { ISettingField, isSettingField } from './setting-field';

--- a/packages/designer/src/designer/setting/setting-top-entry.ts
+++ b/packages/designer/src/designer/setting/setting-top-entry.ts
@@ -4,7 +4,7 @@ import { computed, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor
 import { ISettingEntry } from './setting-entry-type';
 import { ISettingField, SettingField } from './setting-field';
 import { INode } from '../../document';
-import { IComponentMeta } from '../../component-meta';
+import type { IComponentMeta } from '../../component-meta';
 import { IDesigner } from '../designer';
 import { Setters } from '@alilc/lowcode-shell';
 

--- a/packages/designer/src/document/document-model.ts
+++ b/packages/designer/src/document/document-model.ts
@@ -11,7 +11,6 @@ import {
 import {
   IPublicTypeNodeData,
   IPublicTypeNodeSchema,
-  IPublicTypeRootSchema,
   IPublicTypePageSchema,
   IPublicTypeComponentsMap,
   IPublicTypeDragNodeObject,
@@ -21,7 +20,10 @@ import {
   IPublicTypeOnChangeOptions,
   IPublicTypeDisposable,
 } from '@alilc/lowcode-types';
-import {
+import type {
+  IPublicTypeRootSchema,
+} from '@alilc/lowcode-types';
+import type {
   IDropLocation,
 } from '@alilc/lowcode-designer';
 import {
@@ -37,9 +39,10 @@ import {
 } from '@alilc/lowcode-utils';
 import { IProject } from '../project';
 import { ISimulatorHost } from '../simulator';
-import { IComponentMeta } from '../component-meta';
+import type { IComponentMeta } from '../component-meta';
 import { IDesigner, IHistory } from '../designer';
-import { insertChildren, insertChild, IRootNode, INode } from './node/node';
+import { insertChildren, insertChild, IRootNode } from './node/node';
+import type { INode } from './node/node';
 import { Selection, ISelection } from './selection';
 import { History } from './history';
 import { IModalNodesManager, ModalNodesManager, Node } from './node';
@@ -49,11 +52,11 @@ export type GetDataType<T, NodeType> = T extends undefined
   ? NodeType extends {
     schema: infer R;
   }
-    ? R
-    : any
+  ? R
+  : any
   : T;
 
-export interface IDocumentModel extends Omit< IPublicModelDocumentModel<
+export interface IDocumentModel extends Omit<IPublicModelDocumentModel<
   ISelection,
   IHistory,
   INode,
@@ -656,9 +659,9 @@ export class DocumentModel implements IDocumentModel {
   }
 
   checkNesting(
-      dropTarget: INode,
-      dragObject: IPublicTypeDragNodeObject | IPublicTypeNodeSchema | INode | IPublicTypeDragNodeDataObject,
-    ): boolean {
+    dropTarget: INode,
+    dragObject: IPublicTypeDragNodeObject | IPublicTypeNodeSchema | INode | IPublicTypeDragNodeDataObject,
+  ): boolean {
     let items: Array<INode | IPublicTypeNodeSchema>;
     if (isDragNodeDataObject(dragObject)) {
       items = Array.isArray(dragObject.data) ? dragObject.data : [dragObject.data];

--- a/packages/designer/src/document/node/exclusive-group.ts
+++ b/packages/designer/src/document/node/exclusive-group.ts
@@ -1,7 +1,7 @@
 import { obx, computed, makeObservable } from '@alilc/lowcode-editor-core';
 import { uniqueId } from '@alilc/lowcode-utils';
 import { IPublicTypeTitleContent, IPublicModelExclusiveGroup } from '@alilc/lowcode-types';
-import { INode } from './node';
+import type { INode } from './node';
 import { intl } from '../../locale';
 
 export interface IExclusiveGroup extends IPublicModelExclusiveGroup<INode> {

--- a/packages/designer/src/document/node/node.ts
+++ b/packages/designer/src/document/node/node.ts
@@ -21,11 +21,12 @@ import {
 import { compatStage, isDOMText, isJSExpression, isNode, isNodeSchema } from '@alilc/lowcode-utils';
 import { ISettingTopEntry } from '@alilc/lowcode-designer';
 import { Props, getConvertedExtraKey, IProps } from './props/props';
-import { IDocumentModel } from '../document-model';
+import type { IDocumentModel } from '../document-model';
 import { NodeChildren, INodeChildren } from './node-children';
 import { IProp, Prop } from './props/prop';
-import { IComponentMeta } from '../../component-meta';
-import { ExclusiveGroup, IExclusiveGroup, isExclusiveGroup } from './exclusive-group';
+import type { IComponentMeta } from '../../component-meta';
+import { ExclusiveGroup, isExclusiveGroup } from './exclusive-group';
+import type { IExclusiveGroup } from './exclusive-group';
 import { includeSlot, removeSlot } from '../../utils/slot';
 import { foreachReverse } from '../../utils/tree';
 import { NodeRemoveOptions, EDITOR_EVENT } from '../../types';
@@ -1095,7 +1096,7 @@ export class Node<Schema extends IPublicTypeNodeSchema = IPublicTypeNodeSchema> 
           condition(this) !== false :
           condition !== false;
       })
-      .map((action: IPublicTypeComponentAction) => action.name) || [];
+        .map((action: IPublicTypeComponentAction) => action.name) || [];
 
     return availableActions.indexOf(actionName) >= 0;
   }

--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -1,5 +1,6 @@
 import { untracked, computed, obx, engineConfig, action, makeObservable, mobx, runInAction } from '@alilc/lowcode-editor-core';
-import { IPublicTypeCompositeValue, GlobalEvent, IPublicTypeJSSlot, IPublicTypeSlotSchema, IPublicEnumTransformStage, IPublicModelProp } from '@alilc/lowcode-types';
+import { GlobalEvent, IPublicEnumTransformStage } from '@alilc/lowcode-types';
+import type { IPublicTypeCompositeValue, IPublicTypeJSSlot, IPublicTypeSlotSchema, IPublicModelProp } from '@alilc/lowcode-types';
 import { uniqueId, isPlainObject, hasOwnProperty, compatStage, isJSExpression, isJSSlot, isNodeSchema } from '@alilc/lowcode-utils';
 import { valueToSource } from './value-to-source';
 import { IProps, IPropParent } from './props';
@@ -13,7 +14,7 @@ export type UNSET = typeof UNSET;
 
 export interface IProp extends Omit<IPublicModelProp<
   INode
->, 'exportSchema' | 'node' > {
+>, 'exportSchema' | 'node'> {
 
   readonly props: IProps;
 

--- a/packages/designer/src/document/node/props/props.ts
+++ b/packages/designer/src/document/node/props/props.ts
@@ -1,5 +1,6 @@
 import { computed, makeObservable, obx, action } from '@alilc/lowcode-editor-core';
-import { IPublicTypePropsMap, IPublicTypePropsList, IPublicTypeCompositeValue, IPublicEnumTransformStage, IBaseModelProps } from '@alilc/lowcode-types';
+import { IPublicTypePropsList, IPublicTypeCompositeValue, IPublicEnumTransformStage, IBaseModelProps } from '@alilc/lowcode-types';
+import type { IPublicTypePropsMap } from '@alilc/lowcode-types';
 import { uniqueId, compatStage } from '@alilc/lowcode-utils';
 import { Prop, IProp, UNSET } from './prop';
 import { INode } from '../node';

--- a/packages/designer/src/project/project.ts
+++ b/packages/designer/src/project/project.ts
@@ -1,17 +1,20 @@
 import { obx, computed, makeObservable, action, IEventBus, createModuleEventBus } from '@alilc/lowcode-editor-core';
 import { IDesigner } from '../designer';
-import { DocumentModel, IDocumentModel, isDocumentModel } from '../document';
+import { DocumentModel, isDocumentModel } from '../document';
+import type { IDocumentModel } from "../document";
 import {
-  IPublicTypeProjectSchema,
-  IPublicTypeRootSchema,
   IPublicTypeComponentsMap,
   IPublicEnumTransformStage,
   IBaseApiProject,
 } from '@alilc/lowcode-types';
+import type {
+  IPublicTypeProjectSchema,
+  IPublicTypeRootSchema,
+} from '@alilc/lowcode-types';
 import { isLowCodeComponentType, isProCodeComponentType } from '@alilc/lowcode-utils';
 import { ISimulatorHost } from '../simulator';
 
-export interface IProject extends Omit< IBaseApiProject<
+export interface IProject extends Omit<IBaseApiProject<
   IDocumentModel
 >,
   'simulatorHost' |
@@ -146,7 +149,7 @@ export class Project implements IProject {
     return this.documents.reduce<IPublicTypeComponentsMap>((
       componentsMap: IPublicTypeComponentsMap,
       curDoc: IDocumentModel,
-      ): IPublicTypeComponentsMap => {
+    ): IPublicTypeComponentsMap => {
       const curComponentsMap = curDoc.getComponentsMap();
       if (Array.isArray(curComponentsMap)) {
         curComponentsMap.forEach((item) => {
@@ -178,8 +181,8 @@ export class Project implements IProject {
    * 获取项目整体 schema
    */
   getSchema(
-      stage: IPublicEnumTransformStage = IPublicEnumTransformStage.Save,
-    ): IPublicTypeProjectSchema {
+    stage: IPublicEnumTransformStage = IPublicEnumTransformStage.Save,
+  ): IPublicTypeProjectSchema {
     return {
       ...this.data,
       componentsMap: this.getComponentsMap(),

--- a/packages/shell/src/model/condition-group.ts
+++ b/packages/shell/src/model/condition-group.ts
@@ -1,4 +1,4 @@
-import { IExclusiveGroup } from '@alilc/lowcode-designer';
+import type { IExclusiveGroup } from '@alilc/lowcode-designer';
 import { IPublicModelExclusiveGroup, IPublicModelNode } from '@alilc/lowcode-types';
 import { conditionGroupSymbol, nodeSymbol } from '../symbols';
 import { Node } from './node';

--- a/packages/shell/src/model/history.ts
+++ b/packages/shell/src/model/history.ts
@@ -1,4 +1,4 @@
-import { IDocumentModel as InnerDocumentModel, IHistory as InnerHistory } from '@alilc/lowcode-designer';
+import type { IDocumentModel as InnerDocumentModel, IHistory as InnerHistory } from '@alilc/lowcode-designer';
 import { historySymbol, documentSymbol } from '../symbols';
 import { IPublicModelHistory, IPublicTypeDisposable } from '@alilc/lowcode-types';
 

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,4 +1,6 @@
-export { Workspace, IWorkspace } from './workspace';
+export { Workspace } from './workspace';
+export type { IWorkspace } from './workspace';
 export * from './window';
 export * from './layouts/workbench';
-export { Resource, IResource } from './resource';
+export { Resource } from './resource';
+export type { IResource } from './resource';

--- a/packages/workspace/src/workspace.ts
+++ b/packages/workspace/src/workspace.ts
@@ -2,7 +2,8 @@ import { IDesigner, ILowCodePluginManager, LowCodePluginManager } from '@alilc/l
 import { createModuleEventBus, Editor, IEventBus, makeObservable, obx } from '@alilc/lowcode-editor-core';
 import { IPublicApiPlugins, IPublicApiWorkspace, IPublicResourceList, IPublicTypeResourceType, IShellModelFactory } from '@alilc/lowcode-types';
 import { BasicContext } from './context/base-context';
-import { EditorWindow, IEditorWindow } from './window';
+import { EditorWindow } from './window';
+import type { IEditorWindow } from './window';
 import { IResource, Resource } from './resource';
 import { IResourceType, ResourceType } from './resource-type';
 


### PR DESCRIPTION
在 TypeScript 中，使用 export interface 导出的接口，在引入时确实需要使用 import type 来声明。

这是因为 import type 声明的是类型，而不是值，这样可以避免在编译时将接口的定义包含在输出文件中，从而减小输出文件的大小。另外，使用 import type 还可以避免出现循环依赖的问题。

