### PR TITLE
fix: duplicate key "locale" in renderer.ts

### DIFF
--- a/packages/react-simulator-renderer/src/renderer.ts
+++ b/packages/react-simulator-renderer/src/renderer.ts
@@ -461,7 +461,6 @@ export class SimulatorRendererContainer implements BuiltinSimulatorRenderer {
           locale: renderer.locale,
           messages: _schema.i18n || {},
           device: renderer.device,
-          locale: renderer.locale,
           appHelper: renderer.context,
           rendererName: 'LowCodeRenderer',
           thisRequiredInJSE: host.thisRequiredInJSE,


### PR DESCRIPTION
duplicate key "locale" in renderer.ts