### PR TITLE
feat: optimized lowcode types

### DIFF
--- a/packages/types/src/shell/type/metadata.ts
+++ b/packages/types/src/shell/type/metadata.ts
@@ -133,11 +133,13 @@ export interface IPublicTypeLiveTextEditingConfig {
   onSaveContent?: (content: string, prop: any) => any;
 }
 
-export type ConfigureSupportEvent = string | {
+export type ConfigureSupportEvent = string | ConfigureSupportEventConfig;
+
+export interface ConfigureSupportEventConfig {
   name: string;
   propType?: IPublicTypePropType;
   description?: string;
-};
+}
 
 /**
  * 通用扩展面板支持性配置

--- a/packages/types/src/shell/type/node-data.ts
+++ b/packages/types/src/shell/type/node-data.ts
@@ -1,3 +1,3 @@
-import { IPublicTypeJSExpression, IPublicTypeNodeSchema, IPublicTypeDOMText } from './';
+import { IPublicTypeJSExpression, IPublicTypeNodeSchema, IPublicTypeDOMText, IPublicTypeI18nData } from './';
 
-export type IPublicTypeNodeData = IPublicTypeNodeSchema | IPublicTypeJSExpression | IPublicTypeDOMText;
+export type IPublicTypeNodeData = IPublicTypeNodeSchema | IPublicTypeJSExpression | IPublicTypeDOMText | IPublicTypeI18nData;


### PR DESCRIPTION
优化类型

1. 经过测试，IPublicTypeNodeData 是支持渲染  IPublicTypeI18nData
2. 将 ConfigureSupportEvent 配置作为接口而非类型别名，以便更好的扩展该类型。在一些场合(setter) 可能个需要对事件配置做扩展配置

```ts
declare module '@alilc/lowcode-types' {
  export interface ConfigureSupportEventConfig {
    template?: string;
  }
}

export {}
```