### PR TITLE
fix(prop): fix prop.export can not correctly export undefined[]

### DIFF
--- a/packages/designer/src/document/node/props/prop.ts
+++ b/packages/designer/src/document/node/props/prop.ts
@@ -336,13 +336,9 @@ export class Prop implements IProp, IPropParent {
       if (!this._items) {
         return this._value;
       }
-      const values = this.items!.map((prop) => {
+      return this.items!.map((prop) => {
         return prop?.export(stage);
       });
-      if (values.every((val) => val === undefined)) {
-        return undefined;
-      }
-      return values;
     }
   }
 

--- a/packages/designer/tests/document/node/props/prop.test.ts
+++ b/packages/designer/tests/document/node/props/prop.test.ts
@@ -435,7 +435,7 @@ describe('Prop 类测试', () => {
 
       it('should return undefined when all items are undefined', () => {
         prop = new Prop(mockPropsInst, [undefined, undefined], '___loopArgs___');
-        expect(prop.getValue()).toBeUndefined();
+        expect(prop.getValue()).toEqual([undefined, undefined]);
       });
 
       it('迭代器 / map / forEach', () => {


### PR DESCRIPTION
该 PR，为了解决 loopArgs不返回[undefined, undefined]，但是会导致需要设置 prop value 为 undefined[] 类型的设置器，无法获取正确的值。

https://github.com/alibaba/lowcode-engine/pull/141/files

Closes https://github.com/alibaba/lowcode-engine/issues/1891