### PR TITLE
fix: fix proxy plugins.delete not added async

### DIFF
--- a/packages/shell/src/api/plugins.ts
+++ b/packages/shell/src/api/plugins.ts
@@ -66,8 +66,8 @@ export class Plugins implements IPublicApiPlugins {
     return this[pluginsSymbol].has(pluginName);
   }
 
-  delete(pluginName: string) {
-    this[pluginsSymbol].delete(pluginName);
+  async delete(pluginName: string) {
+    return await this[pluginsSymbol].delete(pluginName);
   }
 
   toProxy() {


### PR DESCRIPTION
plugins.delete 取得是name值进行删除，
但是实际上LowCodePluginRuntime的实例被挂载到了Symbol(plugin-instance)，导致plugin. name不能被直接获取
![image](https://user-images.githubusercontent.com/14230248/234752519-fbb5b7c9-37cb-4a24-9069-7b6c8e2c47d9.png)
我无法对lowcode-engine进行开发调试，属于盲改，酌情合并。