### PR TITLE
chore: safer plugins.delete

### DIFF
--- a/packages/designer/src/plugin/plugin-manager.ts
+++ b/packages/designer/src/plugin/plugin-manager.ts
@@ -143,11 +143,10 @@ export class LowCodePluginManager implements ILowCodePluginManager {
   }
 
   async delete(pluginName: string): Promise<boolean> {
-    const idx = this.plugins.findIndex((plugin) => plugin.name === pluginName);
-    if (idx === -1) return false;
-    const plugin = this.plugins[idx];
+    const plugin = this.plugins.find(({ name }) => name === pluginName);
+    if (!plugin) return false;
     await plugin.destroy();
-
+    const idx = this.plugins.indexOf(plugin);
     this.plugins.splice(idx, 1);
     return this.pluginsMap.delete(pluginName);
   }


### PR DESCRIPTION
更安全的plugins.delete，降低使用者心智负担

```js
// e.g. 1
plugins.getAll().forEach((plugin) => {  // 期望全部删除，实际每次仅删除一半
  plugins.delete(plugin.pluginName)
})

// e.g. 2
plugins.delete('OutlinePlugin')  // 正常删除
plugins.delete('___component_meta_parser___') // 无法删除，因 index 是删除 OutlinePlugin 插件前的保存的位置，实际会删除其它plugin
```
e.g.2 也可以通过 #1962 解决
```js
await plugins.delete('OutlinePlugin')
await plugins.delete('___component_meta_parser___')
```
