### PR TITLE
fix: supportVariable SHOULD take precedence over supportVariableGlobally

### DIFF
--- a/packages/editor-skeleton/src/components/settings/settings-pane.tsx
+++ b/packages/editor-skeleton/src/components/settings/settings-pane.tsx
@@ -153,6 +153,14 @@ class SettingFieldView extends Component<SettingFieldViewProps, SettingFieldView
 
     // 根据是否支持变量配置做相应的更改
     const supportVariable = this.field.extraProps?.supportVariable;
+    // supportVariable SHOULD take precedence over supportVariableGlobally
+    if (supportVariable === false) {
+      return {
+        setterProps,
+        initialValue,
+        setterType,
+      };
+    }
     // supportVariableGlobally 只对标准组件生效，vc 需要单独配置
     const supportVariableGlobally = engineConfig.get('supportVariableGlobally', false) && isStandardComponent(componentMeta);
     if (supportVariable || supportVariableGlobally) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -81,6 +81,7 @@ const stageList = [
   'init',
   'upgrade',
 ];
+
 /**
  * 兼容原来的数字版本的枚举对象
  * @param stage
@@ -108,4 +109,18 @@ export function deprecate(fail: any, message: string, alterative?: string) {
 
 export function isRegExp(obj: any): obj is RegExp {
   return obj && obj.test && obj.exec && obj.compile;
+}
+
+/**
+ * The prop supportVariable SHOULD take precedence over default global supportVariable.
+ * @param propSupportVariable prop supportVariable
+ * @param globalSupportVariable global supportVariable
+ * @returns
+ */
+export function shouldUseVariableSetter(
+  propSupportVariable: boolean | undefined,
+  globalSupportVariable: boolean,
+) {
+  if (propSupportVariable === false) return false;
+  return propSupportVariable || globalSupportVariable;
 }

--- a/packages/utils/test/src/misc.test.ts
+++ b/packages/utils/test/src/misc.test.ts
@@ -1,0 +1,9 @@
+import { shouldUseVariableSetter } from '../../src/misc';
+
+it('shouldUseVariableSetter', () => {
+  expect(shouldUseVariableSetter(false, true)).toBeFalsy();
+  expect(shouldUseVariableSetter(true, true)).toBeTruthy();
+  expect(shouldUseVariableSetter(true, false)).toBeTruthy();
+  expect(shouldUseVariableSetter(undefined, false)).toBeFalsy();
+  expect(shouldUseVariableSetter(undefined, true)).toBeTruthy();
+});


### PR DESCRIPTION
Refs: #177 #500 #1938 #1930 

Summary: **supportVariable in single prop definition should OVERLAP the global valve, a.k.a. supportVariableGlobally**~

For Example:
1. supportVariable: false + supportVariableGlobally: true 
-> false
2. supportVariable: true | undefined + supportVariableGlobally: true 
-> true
3. supportVariable: true | undefined + supportVariableGlobally: false 
-> true

