### PR TITLE
feat(ts file format): 出码生成的*.ts和*.tsx文件使用babel格式化

### DIFF
--- a/modules/code-generator/src/postprocessor/prettier/index.ts
+++ b/modules/code-generator/src/postprocessor/prettier/index.ts
@@ -20,7 +20,7 @@ const factory: PostProcessorFactory<ProcessorConfig> = (config?: ProcessorConfig
 
   const codePrettier: PostProcessor = (content: string, fileType: string) => {
     let parser: prettier.BuiltInParserName | any;
-    if (fileType === 'js' || fileType === 'jsx') {
+    if (fileType === 'js' || fileType === 'jsx' || fileType === 'ts' || fileType === 'tsx') {
       parser = 'babel';
     } else if (fileType === 'json') {
       parser = 'json-stringify';


### PR DESCRIPTION
在types/core.ts文件的FileType枚举中支持ts和tsx文件但是出码的时候没有格式化这两种文件，因此增加这两种文件的格式化