### PR TITLE
Update pluginContextMenu.md

### DIFF
--- a/docs/docs/guide/expand/editor/pluginContextMenu.md
+++ b/docs/docs/guide/expand/editor/pluginContextMenu.md
@@ -18,7 +18,6 @@ import { Icon, Message } from '@alifd/next';
 const addHelloAction = (ctx: IPublicModelPluginContext) => {
   return {
     async init() {
-      //const { addBuiltinComponentAction } = ctx.material;
       ctx.material.addBuiltinComponentAction({
         name: 'hello',
         content: {

--- a/docs/docs/guide/expand/editor/pluginContextMenu.md
+++ b/docs/docs/guide/expand/editor/pluginContextMenu.md
@@ -18,8 +18,8 @@ import { Icon, Message } from '@alifd/next';
 const addHelloAction = (ctx: IPublicModelPluginContext) => {
   return {
     async init() {
-      const { addBuiltinComponentAction } = ctx.material;
-      addBuiltinComponentAction({
+      //const { addBuiltinComponentAction } = ctx.material;
+      ctx.material.addBuiltinComponentAction({
         name: 'hello',
         content: {
           icon: <Icon type="atm" />,

--- a/docs/docs/guide/expand/editor/pluginContextMenu.md
+++ b/docs/docs/guide/expand/editor/pluginContextMenu.md
@@ -53,8 +53,7 @@ import { IPublicModelPluginContext } from '@alilc/lowcode-types';
 const removeCopyAction = (ctx: IPublicModelPluginContext) => {
   return {
     async init() {
-      const { removeBuiltinComponentAction } = ctx.material;
-      removeBuiltinComponentAction('copy');
+      ctx.material.removeBuiltinComponentAction('copy');
     }
   }
 };


### PR DESCRIPTION
addBuiltinComponentAction() 在antd.pro版本下不能注册，改为直接使用方式可以。