### PR TITLE
feat: extract simulator type

### DIFF
--- a/packages/designer/src/builtin-simulator/renderer.ts
+++ b/packages/designer/src/builtin-simulator/renderer.ts
@@ -1,29 +1,7 @@
 import { Component } from '../simulator';
-import { IPublicTypeComponentInstance, IPublicTypeNodeInstance, Asset, IPublicTypeComponentSchema, IPublicTypeProjectSchema, IPublicTypeLowCodeComponent } from '@alilc/lowcode-types';
+import { IPublicTypeComponentInstance, IPublicTypeSimulatorRenderer } from '@alilc/lowcode-types';
 
-export interface BuiltinSimulatorRenderer {
-  readonly isSimulatorRenderer: true;
-  autoRepaintNode?: boolean;
-  components: Record<string, Component>;
-  rerender: () => void;
-  createComponent(schema: IPublicTypeProjectSchema<IPublicTypeComponentSchema>): Component | null;
-  getComponent(componentName: string): Component;
-  getClosestNodeInstance(
-      from: IPublicTypeComponentInstance,
-      nodeId?: string,
-    ): IPublicTypeNodeInstance<IPublicTypeComponentInstance> | null;
-  findDOMNodes(instance: IPublicTypeComponentInstance): Array<Element | Text> | null;
-  getClientRects(element: Element | Text): DOMRect[];
-  setNativeSelection(enableFlag: boolean): void;
-  setDraggingState(state: boolean): void;
-  setCopyState(state: boolean): void;
-  loadAsyncLibrary(asyncMap: { [index: string]: any }): void;
-  clearState(): void;
-  stopAutoRepaintNode(): void;
-  enableAutoRepaintNode(): void;
-  run(): void;
-  load(asset: Asset): Promise<any>;
-}
+export type BuiltinSimulatorRenderer = IPublicTypeSimulatorRenderer<Component, IPublicTypeComponentInstance>;
 
 export function isSimulatorRenderer(obj: any): obj is BuiltinSimulatorRenderer {
   return obj && obj.isSimulatorRenderer;

--- a/packages/types/src/shell/type/index.ts
+++ b/packages/types/src/shell/type/index.ts
@@ -90,3 +90,4 @@ export * from './editor-view-config';
 export * from './hotkey-callback-config';
 export * from './hotkey-callbacks';
 export * from './scrollable';
+export * from './simulator-renderer';

--- a/packages/types/src/shell/type/simulator-renderer.ts
+++ b/packages/types/src/shell/type/simulator-renderer.ts
@@ -1,0 +1,32 @@
+import { Asset } from '../../assets';
+import {
+  IPublicTypeNodeInstance,
+  IPublicTypeProjectSchema,
+  IPublicTypeComponentSchema,
+} from './';
+
+export interface IPublicTypeSimulatorRenderer<Component, ComponentInstance> {
+  readonly isSimulatorRenderer: true;
+  autoRepaintNode?: boolean;
+  components: Record<string, Component>;
+  rerender: () => void;
+  createComponent(
+    schema: IPublicTypeProjectSchema<IPublicTypeComponentSchema>,
+  ): Component | null;
+  getComponent(componentName: string): Component;
+  getClosestNodeInstance(
+    from: ComponentInstance,
+    nodeId?: string,
+  ): IPublicTypeNodeInstance<ComponentInstance> | null;
+  findDOMNodes(instance: ComponentInstance): Array<Element | Text> | null;
+  getClientRects(element: Element | Text): DOMRect[];
+  setNativeSelection(enableFlag: boolean): void;
+  setDraggingState(state: boolean): void;
+  setCopyState(state: boolean): void;
+  loadAsyncLibrary(asyncMap: { [index: string]: any }): void;
+  clearState(): void;
+  stopAutoRepaintNode(): void;
+  enableAutoRepaintNode(): void;
+  run(): void;
+  load(asset: Asset): Promise<any>;
+}


### PR DESCRIPTION
将 simulator 类型声明从 designer 中提取到 types 中，便于其他框架的 simulator 实现