### PR TITLE
fix(lowcode-types): allow `template` field in configure.supports.events

### DIFF
--- a/packages/types/src/shell/type/metadata.ts
+++ b/packages/types/src/shell/type/metadata.ts
@@ -139,6 +139,7 @@ export interface ConfigureSupportEventConfig {
   name: string;
   propType?: IPublicTypePropType;
   description?: string;
+  template?: string;
 }
 
 /**


### PR DESCRIPTION
The [document] says we can pass `template` value in `configure.supports.events`.

The implementation shows that both `function-setter` and `event-setter` emit `eventBindDialog.openDialog` event, and `EventBindDialog` truly supports using `template` value, [ref].

So fix the metadata type to allow `template` field.

[document]: https://lowcode-engine.cn/site/docs/guide/appendix/setterDetails/event#%E4%BA%8B%E4%BB%B6%E6%96%B0%E5%BB%BA%E5%87%BD%E6%95%B0%E6%A8%A1%E6%9D%BF
[ref]: https://github.com/alibaba/lowcode-engine-ext/blob/main/src/plugin/plugin-event-bind-dialog/index.tsx#L283