### PR TITLE
fix(code-generator): upgrade prettier parser from babel to babel-ts, fix some ts parse error

### DIFF
--- a/modules/code-generator/src/postprocessor/prettier/index.ts
+++ b/modules/code-generator/src/postprocessor/prettier/index.ts
@@ -21,7 +21,7 @@ const factory: PostProcessorFactory<ProcessorConfig> = (config?: ProcessorConfig
   const codePrettier: PostProcessor = (content: string, fileType: string) => {
     let parser: prettier.BuiltInParserName | any;
     if (fileType === 'js' || fileType === 'jsx' || fileType === 'ts' || fileType === 'tsx') {
-      parser = 'babel';
+      parser = 'babel-ts';
     } else if (fileType === 'json') {
       parser = 'json-stringify';
     } else if (PARSERS.indexOf(fileType) >= 0) {


### PR DESCRIPTION
原有的 babel parser 对于一些新的 ts 语法兼容性不好，会导致如果一些 ts 的代码解析时报错，如
```
class A {
 [key: string]: any; // 这里解析不了
}
```

升级到 babel-ts 后可以修复此问题，两者的区别见 prettier 文档
https://prettier.io/docs/en/options.html#parser