### PR TITLE
feat: remove IPublicTypeFieldExtraProps.virtual definition

### DIFF
--- a/docs/docs/guide/expand/editor/metaSpec.md
+++ b/docs/docs/guide/expand/editor/metaSpec.md
@@ -460,7 +460,6 @@ import parse from '@alilc/lowcode-material-parser';
 {
   name: 'back',
   title: ' ',
-  virtual: () => true,
   display: 'plain',
   setter: BackwardSetter,
 }

--- a/packages/types/src/shell/type/field-extra-props.ts
+++ b/packages/types/src/shell/type/field-extra-props.ts
@@ -44,11 +44,6 @@ export interface IPublicTypeFieldExtraProps {
   autorun?: (target: IPublicModelSettingField) => void;
 
   /**
-   * is this field is a virtual field that not save to schema
-   */
-  virtual?: (target: IPublicModelSettingField) => boolean;
-
-  /**
    * default collapsed when display accordion
    */
   defaultCollapsed?: boolean;


### PR DESCRIPTION
移除 IPublicTypeFieldExtraProps.virtual 相关定义。

> IPublicTypeFieldExtraProps.virtual 只有 ts 定义，没有相关逻辑，也不属于物料协议，属于多余的代码。

fixed https://github.com/alibaba/lowcode-engine/issues/2281