### PR TITLE
revert "fix(material): fix rendering is blocked, when the url in the asset fails to load"

### DIFF
--- a/packages/editor-core/src/editor.ts
+++ b/packages/editor-core/src/editor.ts
@@ -153,11 +153,7 @@ export class Editor extends EventEmitter implements IEditor {
               return;
             }
             if (!AssetsCache[exportName] || !npm?.version || AssetsCache[exportName].npm?.version !== npm?.version) {
-              try {
-                await (new AssetLoader()).load(url);
-              } catch (error) {
-                console.error(`${url} load error: `, error);
-              }
+              await (new AssetLoader()).load(url);
             }
             AssetsCache[exportName] = component;
             function setAssetsComponent(component: any, extraNpmInfo: any = {}) {


### PR DESCRIPTION
Reverts alibaba/lowcode-engine#2388

当资产包 URL 加载出现问题时，资产包有缺失，正常渲染的情况下，会造成这部分组件的 schema 异常，例如 componentMap 异常，不应该做 catch 处理。