### PR TITLE
fix: do not parse props when condition is false or loop data is empty

### DIFF
--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -545,6 +545,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
 
         if (schema.loop != null) {
           const loop = this.__parseData(schema.loop, scope);
+          if (Array.isArray(loop) && loop.length === 0) return null;
           const useLoop = isUseLoop(loop, this.__designModeIsDesign);
           if (useLoop) {
             return this.__createLoopVirtualDom(
@@ -710,7 +711,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
     }
 
     __getSchemaChildrenVirtualDom = (schema: IPublicTypeNodeSchema | undefined, scope: any, Comp: any, condition = true) => {
-      let children = condition ?  getSchemaChildren(schema): null
+      let children = condition ? getSchemaChildren(schema) : null;
 
       // @todo 补完这里的 Element 定义 @承虎
       let result: any = [];

--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -649,7 +649,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
           props.key = props.__id;
         }
 
-        let child = this.__getSchemaChildrenVirtualDom(schema, scope, Comp);
+        let child = this.__getSchemaChildrenVirtualDom(schema, scope, Comp, condition);
         const renderComp = (innerProps: any) => engine.createElement(Comp, innerProps, child);
         // 设计模式下的特殊处理
         if (engine && [DESIGN_MODE.EXTEND, DESIGN_MODE.BORDER].includes(engine.props.designMode)) {
@@ -709,8 +709,8 @@ export default function baseRendererFactory(): IBaseRenderComponent {
       return [];
     }
 
-    __getSchemaChildrenVirtualDom = (schema: IPublicTypeNodeSchema | undefined, scope: any, Comp: any) => {
-      let children = getSchemaChildren(schema);
+    __getSchemaChildrenVirtualDom = (schema: IPublicTypeNodeSchema | undefined, scope: any, Comp: any, condition = true) => {
+      let children = condition ?  getSchemaChildren(schema): null
 
       // @todo 补完这里的 Element 定义 @承虎
       let result: any = [];


### PR DESCRIPTION
- condition 为 false 不执行解析 children props
 
<img width="1613" alt="image" src="https://github.com/alibaba/lowcode-engine/assets/13936318/0f7e39aa-4754-427c-bc8a-7b25e3a5902a">

- 循环组件循环数据为空数组时不继续执行 `__createVirtualDom`
<img width="1613" alt="image" src="https://github.com/alibaba/lowcode-engine/assets/13936318/8e2e0169-6d47-45ec-b3c3-116b05cf549b">
