### PR TITLE
fix: remove unnecessary dep

### DIFF
--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -15,7 +15,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@alilc/build-plugin-lce": "^0.0.4-beta.2",
     "@alilc/lowcode-editor-core": "1.1.10",
     "@alilc/lowcode-types": "1.1.10",
     "@alilc/lowcode-utils": "1.1.10",


### PR DESCRIPTION
在monorepo 的 root 中已经将 @alilc/build-plugin-lce 作为 devDeps 了，这里直接删掉就可以了