### PR TITLE
固定 react-error-overlay 的版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "lockfile": "enable"
   },
   "resolutions": {
-    "typescript": "4.6.2"
+    "typescript": "4.6.2",
+    "react-error-overlay": "6.0.9"
   },
   "repository": "git@github.com:alibaba/lowcode-engine.git"
 }


### PR DESCRIPTION
这是什么问题
![image](https://github.com/alibaba/lowcode-engine/assets/13936318/908fbe50-8829-49f2-8581-a1a7e2a118ce)


`react-error-overlay` 6.0.11 版本里面会有 `process.platform` 在浏览器中会报错， webpack v5 才支持这种方式

详情 → https://github.com/facebook/create-react-app/issues/11773