### PR TITLE
fix: 修复 forwardRef 组件的错误无法捕获

### DIFF
--- a/packages/react-simulator-renderer/test/src/renderer/__snapshots__/demo.test.tsx.snap
+++ b/packages/react-simulator-renderer/test/src/renderer/__snapshots__/demo.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`Base should be render Text 1`] = `
       behavior="NORMAL"
       componentId="node_ockvuu8u916"
       fieldId="text_kvuu9gl2"
+      forwardRef={[Function]}
       maxLine={0}
       showTitle={false}
     >

--- a/packages/renderer-core/src/hoc/index.tsx
+++ b/packages/renderer-core/src/hoc/index.tsx
@@ -1,20 +1,72 @@
 import { cloneEnumerableProperty } from '@alilc/lowcode-utils';
 import adapter from '../adapter';
+import { IBaseRendererInstance, IRendererProps } from '../types';
 
-export function compWrapper(Comp: any) {
+function patchDidCatch(Comp: any, { baseRenderer }: { baseRenderer: IBaseRendererInstance }) {
+  if (Comp.patchedCatch) {
+    return;
+  }
+  Comp.patchedCatch = true;
+  const { PureComponent } = adapter.getRuntime();
+  // Rax 的 getDerivedStateFromError 有 BUG，这里先用 componentDidCatch 来替代
+  // @see https://github.com/alibaba/rax/issues/2211
+  const originalDidCatch = Comp.prototype.componentDidCatch;
+  Comp.prototype.componentDidCatch = function didCatch(this: any, error: Error, errorInfo: any) {
+    this.setState({ engineRenderError: true, error });
+    if (originalDidCatch && typeof originalDidCatch === 'function') {
+      originalDidCatch.call(this, error, errorInfo);
+    }
+  };
+
+  const { engine } = baseRenderer.context;
+  const originRender = Comp.prototype.render;
+  Comp.prototype.render = function () {
+    if (this.state && this.state.engineRenderError) {
+      this.state.engineRenderError = false;
+      return engine.createElement(engine.getFaultComponent(), {
+        ...this.props,
+        error: this.state.error,
+        componentName: this.props._componentName,
+      });
+    }
+    return originRender.call(this);
+  };
+  if (!(Comp.prototype instanceof PureComponent)) {
+    const originShouldComponentUpdate = Comp.prototype.shouldComponentUpdate;
+    Comp.prototype.shouldComponentUpdate = function (nextProps: IRendererProps, nextState: any) {
+      if (nextState && nextState.engineRenderError) {
+        return true;
+      }
+      return originShouldComponentUpdate
+        ? originShouldComponentUpdate.call(this, nextProps, nextState)
+        : true;
+    };
+  }
+}
+
+export function compWrapper(Comp: any, options: { baseRenderer: IBaseRendererInstance }) {
   const { createElement, Component, forwardRef } = adapter.getRuntime();
+  if (
+    Comp?.prototype?.isReactComponent || // react
+    Comp?.prototype?.setState || // rax
+    Comp?.prototype instanceof Component
+  ) {
+    patchDidCatch(Comp, options);
+    return Comp;
+  }
   class Wrapper extends Component {
-    // constructor(props: any, context: any) {
-    //   super(props, context);
-    // }
-
     render() {
-      return createElement(Comp, this.props);
+      return createElement(Comp, { ...this.props, ref: this.props.forwardRef });
     }
   }
   (Wrapper as any).displayName = Comp.displayName;
 
-  return cloneEnumerableProperty(forwardRef((props: any, ref: any) => {
-    return createElement(Wrapper, { ...props, forwardRef: ref });
-  }), Comp);
+  patchDidCatch(Wrapper, options);
+
+  return cloneEnumerableProperty(
+    forwardRef((props: any, ref: any) => {
+      return createElement(Wrapper, { ...props, forwardRef: ref });
+    }),
+    Comp,
+  );
 }

--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -23,7 +23,6 @@ import {
   transformStringToFunction,
   checkPropTypes,
   getI18n,
-  canAcceptsRef,
   getFileCssName,
   capitalizeFirstLetter,
   DataHelper,
@@ -616,11 +615,8 @@ export default function baseRendererFactory(): IBaseRenderComponent {
           });
         });
 
-        // 对于不可以接收到 ref 的组件需要做特殊处理
-        if (!canAcceptsRef(Comp)) {
-          Comp = compWrapper(Comp);
-          components[schema.componentName] = Comp;
-        }
+        Comp = compWrapper(Comp, { baseRenderer: this });
+        components[schema.componentName] = Comp;
 
         otherProps.ref = (ref: any) => {
           this.$(props.fieldId || props.ref, ref); // 收集ref

--- a/packages/renderer-core/src/types/index.ts
+++ b/packages/renderer-core/src/types/index.ts
@@ -335,7 +335,6 @@ export interface IRenderComponent {
     componentDidCatch(e: any): Promise<void> | void;
     shouldComponentUpdate(nextProps: IRendererProps): boolean;
     isValidComponent(SetComponent: any): any;
-    patchDidCatch(SetComponent: any): void;
     createElement(SetComponent: any, props: any, children?: any): any;
     getNotFoundComponent(): any;
     getFaultComponent(): any;

--- a/packages/utils/src/is-react.ts
+++ b/packages/utils/src/is-react.ts
@@ -10,15 +10,24 @@ export function isReactClass(obj: any): obj is ComponentClass<any> {
 }
 
 export function acceptsRef(obj: any): boolean {
-  return obj?.prototype?.isReactComponent || (obj.$$typeof && obj.$$typeof === REACT_FORWARD_REF_TYPE);
+  return obj?.prototype?.isReactComponent || isForwardOrMemoForward(obj);
 }
 
-function isForwardRefType(obj: any): boolean {
+export function isForwardRefType(obj: any): boolean {
   return obj?.$$typeof && obj?.$$typeof === REACT_FORWARD_REF_TYPE;
 }
 
 function isMemoType(obj: any): boolean {
   return obj?.$$typeof && obj.$$typeof === REACT_MEMO_TYPE;
+}
+
+export function isForwardOrMemoForward(obj: any): boolean {
+  return obj?.$$typeof && (
+    // React.forwardRef(..)
+    isForwardRefType(obj) ||
+    // React.memo(React.forwardRef(..))
+    (isMemoType(obj) && isForwardRefType(obj.type))
+  );
 }
 
 export function isReactComponent(obj: any): obj is ComponentType<any> {


### PR DESCRIPTION
### 描述问题
普通函数组件报错（比如需要绑定一个数组绑定成了数字）修改配置后可以恢复
![image](https://github.com/alibaba/lowcode-engine/assets/13936318/07d13e10-91aa-41f2-b078-96c6483b1ca4)
forwardRef 组件报错，比如需要绑定一个数组绑定成了数字）修改配置后无法恢复（修要手动执行 simulatorHost.rerender()才能恢复）
![image](https://github.com/alibaba/lowcode-engine/assets/13936318/f8efbc3d-efce-47c6-b43c-2ba945ae6f1b)


### 修复的问题
1. 如果物料组件不能接受 ref，就包裹一个类组件
https://github.com/alibaba/lowcode-engine/blob/bf980c98ea62eb969af29cfc810f497c3f772509/packages/utils/src/build-components.ts#L114-L118
2. 原有的 patchDidCatch 逻辑只对类组件生效，这会导致 forwardRef 的组件无法捕获错误

### 如何修复
 针对 forwardRef 进行特殊处理