### PR TITLE
fix: fix rendering failure when children is number 0

### DIFF
--- a/packages/renderer-core/src/renderer/base.tsx
+++ b/packages/renderer-core/src/renderer/base.tsx
@@ -455,7 +455,7 @@ export default function baseRendererFactory(): IBaseRenderComponent {
      * @param idx 为循环渲染的循环Index
      */
     __createVirtualDom = (originalSchema: IPublicTypeNodeData | IPublicTypeNodeData[] | undefined, originalScope: any, parentInfo: INodeInfo, idx: string | number = ''): any => {
-      if (!originalSchema) {
+      if (originalSchema === null || originalSchema === undefined) {
         return null;
       }
       let scope = originalScope;


### PR DESCRIPTION
修复当children值为数值0的时候无法正确渲染出来的问题。
<img width="2046" alt="image" src="https://github.com/alibaba/lowcode-engine/assets/1539586/e53c77e4-77e1-490c-a01a-2ee37cf8a3a9">
<img width="2025" alt="image" src="https://github.com/alibaba/lowcode-engine/assets/1539586/daff4a68-cb79-48f2-a587-39e5bdad3138">
