### PR TITLE
fix: createIcon props

### DIFF
--- a/packages/designer/src/builtin-simulator/bem-tools/border-selecting.tsx
+++ b/packages/designer/src/builtin-simulator/bem-tools/border-selecting.tsx
@@ -143,7 +143,7 @@ function createAction(content: ReactNode | ComponentType<any> | IPublicTypeActio
           });
         }}
       >
-        {icon && createIcon(icon)}
+        {icon && createIcon(icon, { key, node })}
         <Tip>{title}</Tip>
       </div>
     );

--- a/packages/designer/src/builtin-simulator/bem-tools/border-selecting.tsx
+++ b/packages/designer/src/builtin-simulator/bem-tools/border-selecting.tsx
@@ -143,7 +143,7 @@ function createAction(content: ReactNode | ComponentType<any> | IPublicTypeActio
           });
         }}
       >
-        {icon && createIcon(icon, { key, node })}
+        {icon && createIcon(icon, { key, node: node.internalToShellNode() })}
         <Tip>{title}</Tip>
       </div>
     );


### PR DESCRIPTION
addBuiltinComponentAction中icon的dom无法获取node节点，建议在 createAction中的 createIcon 补充 key，node参数

issuesId：#2622
[](https://github.com/alibaba/lowcode-engine/issues/2622)