### PR TITLE
fix config.set('customizeIgnoreSelectors') not work

### DIFF
--- a/packages/designer/src/builtin-simulator/host.ts
+++ b/packages/designer/src/builtin-simulator/host.ts
@@ -716,7 +716,7 @@ export class BuiltinSimulatorHost implements ISimulatorHost<BuiltinSimulatorProp
           '.next-calendar-table',
           '.editor-container', // 富文本组件
         ];
-        const ignoreSelectors = customizeIgnoreSelectors?.(defaultIgnoreSelectors, e) || defaultIgnoreSelectors;
+        const ignoreSelectors = customizeIgnoreSelectors?.concat(defaultIgnoreSelectors) || defaultIgnoreSelectors;
         const ignoreSelectorsString = ignoreSelectors.join(',');
         // 提供了 customizeIgnoreSelectors 的情况下，忽略 isFormEvent() 判断
         if ((!customizeIgnoreSelectors && isFormEvent(e)) || target?.closest(ignoreSelectorsString)) {


### PR DESCRIPTION
根据此[issue 2223](https://github.com/alibaba/lowcode-engine/issues/2223) 发现该方法会报错导致无法正常工作，经过调试提出修改方案如commit所示。
经测试后该方法可以正常使用。

`
// 任意可获取到config的地方

config.set('customizeIgnoreSelectors', ['.next-btn'])
`